### PR TITLE
Expand to do list in Dashboard

### DIFF
--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -7,28 +7,10 @@ from firebase_config import db
 
 app = Flask(__name__)
 CORS(app)
-tasks = db.collection('tasks')
+public_tasks = db.collection('public_tasks')
 
-@app.route('/')
-def home():
-    return jsonify({"message": "Unigenda backend is running"})
 
-@app.route('/testdb')
-def test_db():
-    tasks.add({"task": "Test task"})
-    return {"message": "Task added"}
-
-@app.route('/public_tasks')
-def get_public_tasks():
-    task_list = []
-    for task in tasks.stream():
-        task_list.append(task.to_dict())
-    return jsonify(task_list)
-## -- CRUD Operations -- ##
-# CREATE
-@app.route('/tasks', methods=['POST'])
-def add_task():
-    # Accept JSON payloads and gracefully fallback for form/raw bodies
+def parse_payload():
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         if request.form:
@@ -38,17 +20,52 @@ def add_task():
                 data = json.loads(request.data.decode('utf-8'))
             except Exception:
                 data = None
+    return data
+
+
+def normalize_tags(raw_tags):
+    if isinstance(raw_tags, str):
+        return [tag.strip() for tag in raw_tags.split(',') if tag.strip()]
+    if isinstance(raw_tags, list):
+        return [str(tag).strip() for tag in raw_tags if str(tag).strip()]
+    return []
+
+
+def sync_public_task(task_id, task_data):
+    if task_data.get('isPublic'):
+        public_tasks.document(task_id).set(task_data)
+    else:
+        public_tasks.document(task_id).delete()
+
+
+def get_user_task_ref(user_id, task_id):
+    return db.collection('users').document(user_id).collection('tasks').document(task_id)
+
+@app.route('/')
+def home():
+    return jsonify({"message": "Unigenda backend is running"})
+
+@app.route('/testdb')
+def test_db():
+    db.collection('users').document('test-user').collection('tasks').add({"task": "Test task"})
+    return {"message": "Task added"}
+
+@app.route('/public_tasks')
+def get_public_tasks():
+    task_list = []
+    for task in public_tasks.stream():
+        task_list.append(task.to_dict() | {"id": task.id})
+    return jsonify(task_list)
+## -- CRUD Operations -- ##
+# CREATE
+@app.route('/tasks', methods=['POST'])
+def add_task():
+    data = parse_payload()
 
     if not isinstance(data, dict):
         return jsonify({"error": "Invalid or missing request body. Send JSON with Content-Type: application/json."}), 400
 
-    raw_tags = data.get('tags', [])
-    if isinstance(raw_tags, str):
-        tags = [tag.strip() for tag in raw_tags.split(',') if tag.strip()]
-    elif isinstance(raw_tags, list):
-        tags = [str(tag).strip() for tag in raw_tags if str(tag).strip()]
-    else:
-        tags = []
+    tags = normalize_tags(data.get('tags', []))
 
     visibility = data.get('visibility', 'private')
     is_public = bool(data.get('isPublic', visibility == 'public'))
@@ -72,18 +89,60 @@ def add_task():
         "createdAt": firestore.SERVER_TIMESTAMP
     }
 
-    # Use a single task id in both places:
-    # 1) Global collection (existing behavior)
-    # 2) User-scoped subcollection (users/{uid}/tasks)
-    task_ref = db.collection('tasks').document()
+    # Store task only in user-scoped subcollection
+    user_ref = db.collection('users').document(user_id)
+    user_ref.set({"updatedAt": firestore.SERVER_TIMESTAMP}, merge=True)
+
+    task_ref = user_ref.collection('tasks').document()
     task_id = task_ref.id
     task_ref.set(new_task)
 
-    user_ref = db.collection('users').document(user_id)
-    user_ref.set({"updatedAt": firestore.SERVER_TIMESTAMP}, merge=True)
-    user_ref.collection('tasks').document(task_id).set(new_task)
+    sync_public_task(task_id, new_task)
 
     return jsonify({"id": task_id, "message": "Task created"}), 201
+
+# Might have to 
+@app.route('/public_tasks', methods=['POST'])
+def add_public_task():
+    data = parse_payload()
+
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body. Send JSON with Content-Type: application/json."}), 400
+
+    data['visibility'] = 'public'
+    data['isPublic'] = True
+
+    tags = normalize_tags(data.get('tags', []))
+    user_id = data.get("userId")
+
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+    if not data.get('title'):
+        return jsonify({"error": "title is required"}), 400
+
+    new_task = {
+        "title": data.get('title'),
+        "description": data.get('description'),
+        "dueDate": data.get("dueDate"),
+        "userId": user_id,
+        "priority": data.get("priority", "medium"),
+        "visibility": "public",
+        "isPublic": True,
+        "tags": tags,
+        "status": "pending",
+        "createdAt": firestore.SERVER_TIMESTAMP
+    }
+
+    user_ref = db.collection('users').document(user_id)
+    user_ref.set({"updatedAt": firestore.SERVER_TIMESTAMP}, merge=True)
+
+    task_ref = user_ref.collection('tasks').document()
+    task_id = task_ref.id
+    task_ref.set(new_task)
+
+    public_tasks.document(task_id).set(new_task)
+
+    return jsonify({"id": task_id, "message": "Public task created"}), 201
 # READ
 @app.route('/tasks/<uid>', methods=['GET'])
 def get_user_tasks(uid):
@@ -91,7 +150,7 @@ def get_user_tasks(uid):
     limit = request.args.get('limit', default=20, type=int)
     
     try: 
-        # Prefer user-scoped tasks collection
+        # User-scoped tasks collection
         scoped_tasks = db.collection('users') \
             .document(uid) \
             .collection('tasks') \
@@ -100,15 +159,6 @@ def get_user_tasks(uid):
             .stream()
         task_list = [task.to_dict() | {"id": task.id} for task in scoped_tasks]
 
-        # Fallback for older tasks that were only stored globally
-        if not task_list:
-            user_tasks = db.collection('tasks') \
-                .where('userId', '==', uid)     \
-                .order_by('dueDate', direction=firestore.Query.ASCENDING)            \
-                .limit(limit)                   \
-                .stream()
-            task_list = [task.to_dict() | {"id": task.id} for task in user_tasks]
-
         return jsonify(task_list), 200
     except Exception as e:
         # if index has not been created, Firestore returns error
@@ -116,14 +166,123 @@ def get_user_tasks(uid):
 # UPDATE
 @app.route('/tasks/<task_id>', methods=['PATCH'])
 def update_task(task_id):
-    data = request.json
-    task_ref = db.collection('tasks').document(task_id)
-    task_ref.update({"status": data.get("status")}) # e.g., "status: completed"
+    data = parse_payload()
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body."}), 400
+
+    user_id = data.get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    task_ref = get_user_task_ref(user_id, task_id)
+    task_snapshot = task_ref.get()
+    if not task_snapshot.exists:
+        return jsonify({"error": "Task not found"}), 404
+
+    current_task = task_snapshot.to_dict()
+
+    updates = {}
+    if "title" in data:
+        updates["title"] = data.get("title")
+    if "description" in data:
+        updates["description"] = data.get("description")
+    if "dueDate" in data:
+        updates["dueDate"] = data.get("dueDate")
+    if "status" in data:
+        updates["status"] = data.get("status")
+    if "priority" in data:
+        updates["priority"] = data.get("priority")
+    if "tags" in data:
+        updates["tags"] = normalize_tags(data.get("tags"))
+    if "visibility" in data or "isPublic" in data:
+        next_public = bool(data.get("isPublic", data.get("visibility") == "public"))
+        updates["isPublic"] = next_public
+        updates["visibility"] = "public" if next_public else "private"
+
+    if not updates:
+        return jsonify({"error": "No valid fields to update"}), 400
+
+    task_ref.set(updates, merge=True)
+
+    updated_task = current_task | updates
+    sync_public_task(task_id, updated_task)
+
     return jsonify({"message": "Task updated"}), 200
 # DELETE
 @app.route('/tasks/<task_id>', methods=['DELETE'])
 def delete_task(task_id):
-    db.collection('tasks').document(task_id).delete()
+    user_id = request.args.get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    task_snapshot = get_user_task_ref(user_id, task_id).get()
+    if task_snapshot.exists:
+        get_user_task_ref(user_id, task_id).delete()
+    public_tasks.document(task_id).delete()
+
+    return jsonify({"message": "Task deleted"}), 200
+
+
+@app.route('/public_tasks/<task_id>', methods=['PATCH'])
+def update_public_task(task_id):
+    data = parse_payload()
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body."}), 400
+
+    user_id = data.get("userId")
+    if not user_id:
+        public_snapshot = public_tasks.document(task_id).get()
+        if public_snapshot.exists:
+            user_id = public_snapshot.to_dict().get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    task_ref = get_user_task_ref(user_id, task_id)
+    task_snapshot = task_ref.get()
+    if not task_snapshot.exists:
+        return jsonify({"error": "Task not found"}), 404
+
+    current_task = task_snapshot.to_dict()
+
+    updates = {
+        "visibility": "public",
+        "isPublic": True
+    }
+    if "title" in data:
+        updates["title"] = data.get("title")
+    if "description" in data:
+        updates["description"] = data.get("description")
+    if "dueDate" in data:
+        updates["dueDate"] = data.get("dueDate")
+    if "status" in data:
+        updates["status"] = data.get("status")
+    if "priority" in data:
+        updates["priority"] = data.get("priority")
+    if "tags" in data:
+        updates["tags"] = normalize_tags(data.get("tags"))
+
+    task_ref.set(updates, merge=True)
+
+    updated_task = current_task | updates
+    public_tasks.document(task_id).set(updated_task)
+    return jsonify({"message": "Public task updated"}), 200
+
+
+@app.route('/public_tasks/<task_id>', methods=['DELETE'])
+def delete_public_task(task_id):
+    user_id = request.args.get("userId")
+    if not user_id:
+        public_snapshot = public_tasks.document(task_id).get()
+        if public_snapshot.exists:
+            user_id = public_snapshot.to_dict().get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    task_snapshot = get_user_task_ref(user_id, task_id).get()
+    if task_snapshot.exists:
+        get_user_task_ref(user_id, task_id).delete()
+    public_tasks.document(task_id).delete()
+
     return jsonify({"message": "Task deleted"}), 200
 ## -- --------------- -- ##
 

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -27,11 +27,27 @@ def get_tasks():
 @app.route('/tasks', methods=['POST'])
 def add_task():
     data = request.json
+
+    raw_tags = data.get('tags', [])
+    if isinstance(raw_tags, str):
+        tags = [tag.strip() for tag in raw_tags.split(',') if tag.strip()]
+    elif isinstance(raw_tags, list):
+        tags = [str(tag).strip() for tag in raw_tags if str(tag).strip()]
+    else:
+        tags = []
+
+    visibility = data.get('visibility', 'private')
+    is_public = bool(data.get('isPublic', visibility == 'public'))
+
     new_task = {
         "title": data.get('title'),
         "description": data.get('description'),
         "dueDate": data.get("dueDate"),
         "userId": data.get("userId"), # The student's User ID from Auth
+        "priority": data.get("priority", "medium"),
+        "visibility": "public" if is_public else "private",
+        "isPublic": is_public,
+        "tags": tags,
         "status": "pending",
         "createdAt": firestore.SERVER_TIMESTAMP
     }

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -50,16 +50,24 @@ def test_db():
     db.collection('users').document('test-user').collection('tasks').add({"task": "Test task"})
     return {"message": "Task added"}
 
-@app.route('/public_tasks')
-def get_public_tasks():
-    task_list = []
-    for task in public_tasks.stream():
-        task_list.append(task.to_dict() | {"id": task.id})
-    return jsonify(task_list)
-## -- CRUD Operations -- ##
+
+
+## -- CRUD Operations for Profiles -- ##
+@app.route('/users/<uid>', methods=['GET'])
+def get_user_profile(uid):
+    try:
+        user_doc = db.collection('users').document(uid).get()
+        if not user_doc.exists:
+            return jsonify({"error": "Profile not found"}), 404
+
+        profile = user_doc.to_dict() or {}
+        return jsonify(profile), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+## -- CRUD Operations for Tasks -- ##
 # CREATE
-@app.route('/tasks', methods=['POST'])
-def add_task():
+@app.route('/users/<uid>/tasks', methods=['POST'])
+def add_task(uid):
     data = parse_payload()
 
     if not isinstance(data, dict):
@@ -102,49 +110,9 @@ def add_task():
     return jsonify({"id": task_id, "message": "Task created"}), 201
 
 # Might have to 
-@app.route('/public_tasks', methods=['POST'])
-def add_public_task():
-    data = parse_payload()
 
-    if not isinstance(data, dict):
-        return jsonify({"error": "Invalid or missing request body. Send JSON with Content-Type: application/json."}), 400
-
-    data['visibility'] = 'public'
-    data['isPublic'] = True
-
-    tags = normalize_tags(data.get('tags', []))
-    user_id = data.get("userId")
-
-    if not user_id:
-        return jsonify({"error": "userId is required"}), 400
-    if not data.get('title'):
-        return jsonify({"error": "title is required"}), 400
-
-    new_task = {
-        "title": data.get('title'),
-        "description": data.get('description'),
-        "dueDate": data.get("dueDate"),
-        "userId": user_id,
-        "priority": data.get("priority", "medium"),
-        "visibility": "public",
-        "isPublic": True,
-        "tags": tags,
-        "status": "pending",
-        "createdAt": firestore.SERVER_TIMESTAMP
-    }
-
-    user_ref = db.collection('users').document(user_id)
-    user_ref.set({"updatedAt": firestore.SERVER_TIMESTAMP}, merge=True)
-
-    task_ref = user_ref.collection('tasks').document()
-    task_id = task_ref.id
-    task_ref.set(new_task)
-
-    public_tasks.document(task_id).set(new_task)
-
-    return jsonify({"id": task_id, "message": "Public task created"}), 201
 # READ
-@app.route('/tasks/<uid>', methods=['GET'])
+@app.route('/users/<uid>/tasks', methods=['GET'])
 def get_user_tasks(uid):
     # Default limit of fetching amount is 20
     limit = request.args.get('limit', default=20, type=int)
@@ -164,8 +132,8 @@ def get_user_tasks(uid):
         # if index has not been created, Firestore returns error
         return jsonify({"error": str(e)}), 400
 # UPDATE
-@app.route('/tasks/<task_id>', methods=['PATCH'])
-def update_task(task_id):
+@app.route('/users/<uid>/tasks/<task_id>', methods=['PATCH'])
+def update_task(uid, task_id):
     data = parse_payload()
     if not isinstance(data, dict):
         return jsonify({"error": "Invalid or missing request body."}), 400
@@ -209,7 +177,7 @@ def update_task(task_id):
 
     return jsonify({"message": "Task updated"}), 200
 # DELETE
-@app.route('/tasks/<task_id>', methods=['DELETE'])
+@app.route('/users/<uid>/tasks', methods=['DELETE'])
 def delete_task(task_id):
     user_id = request.args.get("userId")
     if not user_id:
@@ -221,8 +189,48 @@ def delete_task(task_id):
     public_tasks.document(task_id).delete()
 
     return jsonify({"message": "Task deleted"}), 200
+## -- Public Tasks -- ##
+@app.route('/public_tasks', methods=['POST'])
+def add_public_task():
+    data = parse_payload()
 
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body. Send JSON with Content-Type: application/json."}), 400
 
+    data['visibility'] = 'public'
+    data['isPublic'] = True
+
+    tags = normalize_tags(data.get('tags', []))
+    user_id = data.get("userId")
+
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+    if not data.get('title'):
+        return jsonify({"error": "title is required"}), 400
+
+    new_task = {
+        "title": data.get('title'),
+        "description": data.get('description'),
+        "dueDate": data.get("dueDate"),
+        "userId": user_id,
+        "priority": data.get("priority", "medium"),
+        "visibility": "public",
+        "isPublic": True,
+        "tags": tags,
+        "status": "pending",
+        "createdAt": firestore.SERVER_TIMESTAMP
+    }
+
+    user_ref = db.collection('users').document(user_id)
+    user_ref.set({"updatedAt": firestore.SERVER_TIMESTAMP}, merge=True)
+
+    task_ref = user_ref.collection('tasks').document()
+    task_id = task_ref.id
+    task_ref.set(new_task)
+
+    public_tasks.document(task_id).set(new_task)
+
+    return jsonify({"id": task_id, "message": "Public task created"}), 201
 @app.route('/public_tasks/<task_id>', methods=['PATCH'])
 def update_public_task(task_id):
     data = parse_payload()
@@ -267,6 +275,12 @@ def update_public_task(task_id):
     public_tasks.document(task_id).set(updated_task)
     return jsonify({"message": "Public task updated"}), 200
 
+@app.route('/public_tasks')
+def get_public_tasks():
+    task_list = []
+    for task in public_tasks.stream():
+        task_list.append(task.to_dict() | {"id": task.id})
+    return jsonify(task_list)
 
 @app.route('/public_tasks/<task_id>', methods=['DELETE'])
 def delete_public_task(task_id):

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 from firebase_admin import firestore
@@ -16,8 +18,8 @@ def test_db():
     tasks.add({"task": "Test task"})
     return {"message": "Task added"}
 
-@app.route('/tasks')
-def get_tasks():
+@app.route('/public_tasks')
+def get_public_tasks():
     task_list = []
     for task in tasks.stream():
         task_list.append(task.to_dict())
@@ -26,7 +28,19 @@ def get_tasks():
 # CREATE
 @app.route('/tasks', methods=['POST'])
 def add_task():
-    data = request.json
+    # Accept JSON payloads and gracefully fallback for form/raw bodies
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        if request.form:
+            data = request.form.to_dict(flat=True)
+        elif request.data:
+            try:
+                data = json.loads(request.data.decode('utf-8'))
+            except Exception:
+                data = None
+
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body. Send JSON with Content-Type: application/json."}), 400
 
     raw_tags = data.get('tags', [])
     if isinstance(raw_tags, str):
@@ -38,12 +52,18 @@ def add_task():
 
     visibility = data.get('visibility', 'private')
     is_public = bool(data.get('isPublic', visibility == 'public'))
+    user_id = data.get("userId")
+
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+    if not data.get('title'):
+        return jsonify({"error": "title is required"}), 400
 
     new_task = {
         "title": data.get('title'),
         "description": data.get('description'),
         "dueDate": data.get("dueDate"),
-        "userId": data.get("userId"), # The student's User ID from Auth
+        "userId": user_id, # The student's User ID from Auth
         "priority": data.get("priority", "medium"),
         "visibility": "public" if is_public else "private",
         "isPublic": is_public,
@@ -51,8 +71,19 @@ def add_task():
         "status": "pending",
         "createdAt": firestore.SERVER_TIMESTAMP
     }
-    doc_ref = db.collection('tasks').add(new_task)
-    return jsonify({"id": doc_ref[1].id, "message": "Task created"}), 201
+
+    # Use a single task id in both places:
+    # 1) Global collection (existing behavior)
+    # 2) User-scoped subcollection (users/{uid}/tasks)
+    task_ref = db.collection('tasks').document()
+    task_id = task_ref.id
+    task_ref.set(new_task)
+
+    user_ref = db.collection('users').document(user_id)
+    user_ref.set({"updatedAt": firestore.SERVER_TIMESTAMP}, merge=True)
+    user_ref.collection('tasks').document(task_id).set(new_task)
+
+    return jsonify({"id": task_id, "message": "Task created"}), 201
 # READ
 @app.route('/tasks/<uid>', methods=['GET'])
 def get_user_tasks(uid):
@@ -60,14 +91,24 @@ def get_user_tasks(uid):
     limit = request.args.get('limit', default=20, type=int)
     
     try: 
-        # Only fetch tasks where the 'userId' matches the student
-        # Order it by dueDate
-        user_tasks = db.collection('tasks') \
-            .where('userId', '==', uid)     \
-            .order_by('dueDate', direction=firestore.Query.ASCENDING)            \
-            .limit(limit)                   \
+        # Prefer user-scoped tasks collection
+        scoped_tasks = db.collection('users') \
+            .document(uid) \
+            .collection('tasks') \
+            .order_by('dueDate', direction=firestore.Query.ASCENDING) \
+            .limit(limit) \
             .stream()
-        task_list = [task.to_dict() | {"id": task.id} for task in user_tasks]
+        task_list = [task.to_dict() | {"id": task.id} for task in scoped_tasks]
+
+        # Fallback for older tasks that were only stored globally
+        if not task_list:
+            user_tasks = db.collection('tasks') \
+                .where('userId', '==', uid)     \
+                .order_by('dueDate', direction=firestore.Query.ASCENDING)            \
+                .limit(limit)                   \
+                .stream()
+            task_list = [task.to_dict() | {"id": task.id} for task in user_tasks]
+
         return jsonify(task_list), 200
     except Exception as e:
         # if index has not been created, Firestore returns error

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState } from "react";
 import { auth, db } from "../firebase"; 
 import { doc, getDoc } from "firebase/firestore";
-import { signOut } from "firebase/auth"; //
+import { onAuthStateChanged, signOut } from "firebase/auth"; //
 import { useNavigate } from "react-router-dom";
 import "../styles/Dashboard.css";
 import TaskForm from './TaskForm';
@@ -14,21 +14,29 @@ const Dashboard = () => {
     const [refresh, setRefresh] = useState(0);
 
     useEffect(()=> {
-        const user = auth. currentUser;
+        const unsubscribe = onAuthStateChanged(auth, async (user) => {
+            if (!user) {
+                setUserData(null);
+                return;
+            }
 
-        if(user){
-            // Maps UserID to Firestore document
-            const fetchProfile = async() => {
+            try {
+                // Maps UserID to Firestore document
                 const docRef = doc(db, "users", user.uid);
                 const docSnap = await getDoc(docRef);
 
                 if(docSnap.exists()){
                     setUserData(docSnap.data());
+                } else {
+                    setUserData(null);
                 }
-            };
-            fetchProfile();
-        }
+            } catch (error) {
+                console.error("Error loading user profile:", error);
+                setUserData(null);
+            }
+        });
 
+        return () => unsubscribe();
     }, []);
     const handleLogout = async () => {
         try {

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState } from "react";
-import { auth, db } from "../firebase"; 
-import { doc, getDoc } from "firebase/firestore";
+import axios from "axios";
+import { auth } from "../firebase"; 
 import { onAuthStateChanged, signOut } from "firebase/auth"; //
 import { useNavigate } from "react-router-dom";
 import "../styles/Dashboard.css";
@@ -10,26 +10,22 @@ import TaskList from './TaskList';
 
 const Dashboard = () => {
     const [userData, setUserData] = useState(null);
+    const [authUser, setAuthUser] = useState(null);
     const navigate = useNavigate();
     const [refresh, setRefresh] = useState(0);
 
     useEffect(()=> {
         const unsubscribe = onAuthStateChanged(auth, async (user) => {
+            setAuthUser(user);
+
             if (!user) {
                 setUserData(null);
                 return;
             }
 
             try {
-                // Maps UserID to Firestore document
-                const docRef = doc(db, "users", user.uid);
-                const docSnap = await getDoc(docRef);
-
-                if(docSnap.exists()){
-                    setUserData(docSnap.data());
-                } else {
-                    setUserData(null);
-                }
+                const response = await axios.get(`http://127.0.0.1:5000/users/${user.uid}`);
+                setUserData(response.data || null);
             } catch (error) {
                 console.error("Error loading user profile:", error);
                 setUserData(null);
@@ -51,19 +47,33 @@ const Dashboard = () => {
         setRefresh(prev => prev + 1); // Increment to trigger useEffect in TaskList
     };
 
+    const welcomeName =
+        userData?.displayName ||
+        userData?.firstName ||
+        authUser?.displayName ||
+        authUser?.email?.split('@')[0] ||
+        "Student (Name not loaded)";
+
+    const affiliationLabel =
+        userData?.school === "UF"
+            ? "University of Florida"
+            : userData?.school === "SF"
+                ? "Santa Fe College"
+                : userData?.school;
+    
     return (
         <div className="dashboard-page-wrapper">
             <div className="dashboard-layout">   
                 {/* 3. Display the unique profile data */}
-                <h1>Welcome, {userData?.displayName || "Student (No Data Loaded)"}!</h1>
-                <p>Affiliation: {userData?.school}</p>
+                <h1>Welcome, {welcomeName}!</h1>
+                <p>Affiliation: {affiliationLabel || "School not loaded"}</p>
                 {/* Input Section */}
                 <TaskForm onTaskAdded={handleTaskAdded} />
                 
                 <hr className="section-divider" />
                 
                 {/* Display Section */}
-                <h3>Upcoming Tasks</h3>
+                <h3>Tasks</h3>
                 <TaskList refreshTrigger={refresh} />
                 
                 <hr className="section-divider" />

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -4,7 +4,7 @@ import { doc, getDoc } from "firebase/firestore";
 import { onAuthStateChanged, signOut } from "firebase/auth"; //
 import { useNavigate } from "react-router-dom";
 import "../styles/Dashboard.css";
-import TaskForm from './TaskForm';
+import TaskForm from './task-components/TaskForm';
 import TaskList from './TaskList';
 
 

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -80,9 +80,11 @@ const Login = ({mode, onClose }) => { // False means it is login, True means it 
               Don't have an account? <Link to="/sign_up">Sign up!</Link>
             </p>
           )}
-          <p>
-            Back to <Link to="/">Home Page</Link>
-          </p>
+          {!isPopup && (
+            <p>
+              Back to <Link to="/">Home Page</Link>
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -28,9 +28,18 @@ const NavBar = ({ user }) => {
     if (!user?.uid) {
       return;
     }
-    getDoc(doc(db, "users", user.uid)).then((snap) => {
-      setIsAdmin(snap.exists() && snap.data()?.isAdmin === true);
-    });
+
+    const fetchRole = async () => {
+      try {
+        const snap = await getDoc(doc(db, "users", user.uid));
+        setIsAdmin(snap.exists() && snap.data()?.isAdmin === true);
+      } catch (error) {
+        console.error("Error loading user role:", error);
+        setIsAdmin(false);
+      }
+    };
+
+    fetchRole();
   }, [user?.uid]);
 
   const visibleItems = (group) =>

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -12,9 +12,18 @@ const ProtectedRoute = ({ children, adminOnly = false }) => {
     if (!adminOnly || !user) {
       return;
     }
-    getDoc(doc(db, "users", user.uid)).then((snap) => {
-      setIsAdmin(snap.exists() && snap.data()?.isAdmin === true);
-    });
+
+    const checkAdmin = async () => {
+      try {
+        const snap = await getDoc(doc(db, "users", user.uid));
+        setIsAdmin(snap.exists() && snap.data()?.isAdmin === true);
+      } catch (error) {
+        console.error("Error checking admin status:", error);
+        setIsAdmin(false);
+      }
+    };
+
+    checkAdmin();
   }, [adminOnly, user]);
 
   if (!user) {

--- a/frontend/src/components/Registration.js
+++ b/frontend/src/components/Registration.js
@@ -4,7 +4,7 @@ import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { auth, db } from "../firebase"; 
 import { doc, setDoc } from "firebase/firestore";
 // -------- //
-import { useLocation, useNavigate, Link } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import "../styles/Registration.css";
 
 const Registration = () => {
@@ -144,11 +144,6 @@ const Registration = () => {
           <hr className="section-divider" />
           <button type="submit">Complete Registration</button>
         </form>
-        <div className="auth-footer">
-          <p>
-            Back to <Link to="/">Home Page</Link>
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/TaskForm.js
+++ b/frontend/src/components/TaskForm.js
@@ -5,24 +5,41 @@ import { auth } from '../firebase';
 const TaskForm = ({ onTaskAdded }) => {
     const [title, setTitle]      = useState('');
     const [dueDate, setDueDate]  = useState('');
-    // const [userID, setDueDate] = useState('');
-    // const [description, setDescription] = useState('');
+    const [priority, setPriority] = useState('medium');
+    const [visibility, setVisibility] = useState('private');
+    const [description, setDescription] = useState('');
+    const [tags, setTags] = useState('');
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         const user = auth.currentUser;
 
         if(!user) return; // user does not exist
+
+        const parsedTags = tags
+            .split(',')
+            .map((tag) => tag.trim())
+            .filter((tag) => tag.length > 0);
+
         const newTask = {
             title: title,
             dueDate: dueDate,
             userId: user.uid, // links task to specified user ID
-            description: "Demo Task" // TO-DO: change after sprint 1 presentation
+            description: description,
+            priority: priority,
+            visibility: visibility,
+            isPublic: visibility === 'public',
+            tags: parsedTags
         };
 
         try{
             await axios.post('http://127.0.0.1:5000/tasks', newTask);
             setTitle("");
             setDueDate("");
+            setPriority('medium');
+            setVisibility('private');
+            setDescription('');
+            setTags('');
             if(onTaskAdded) onTaskAdded(); // Refreshes the list after adding
         } catch(err) {
             console.error("Error adding task: ", err);
@@ -44,6 +61,33 @@ const TaskForm = ({ onTaskAdded }) => {
                 value={dueDate}
                 onChange={(e) => setDueDate(e.target.value)}
                 required 
+                />
+                <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value)}
+                >
+                    <option value="low">Low Priority</option>
+                    <option value="medium">Medium Priority</option>
+                    <option value="high">High Priority</option>
+                </select>
+                <select
+                value={visibility}
+                onChange={(e) => setVisibility(e.target.value)}
+                >
+                    <option value="private">Private</option>
+                    <option value="public">Public</option>
+                </select>
+                <textarea
+                placeholder="Task Description (optional)"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                />
+                <input
+                type="text"
+                placeholder="Tags (comma-separated, e.g., exam, math, group-work)"
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
                 />
                 <button type="submit">Add to UniGenda</button>
         </form>

--- a/frontend/src/components/TaskList.js
+++ b/frontend/src/components/TaskList.js
@@ -2,11 +2,16 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { auth } from '../firebase';
 import { onAuthStateChanged } from 'firebase/auth';
+import '../styles/TaskRelatedStyles.css';
 
 const TaskList = ({ refreshTrigger }) => {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [uid, setUid] = useState(null);
+  const [deletingTaskId, setDeletingTaskId] = useState(null);
+  const [confirmingTaskId, setConfirmingTaskId] = useState(null);
+  const [expandedTaskIds, setExpandedTaskIds] = useState({});
+  const [activeTab, setActiveTab] = useState('uncompleted'); // 'uncompleted' or 'completed'
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
@@ -26,7 +31,7 @@ const TaskList = ({ refreshTrigger }) => {
     const fetchTasks = async () => {
       try {
         // Fetching sorted/limited tasks from your Flask API
-        const response = await axios.get(`http://127.0.0.1:5000/tasks/${uid}?limit=10`);
+        const response = await axios.get(`http://127.0.0.1:5000/users/${uid}/tasks?limit=10`);
         setTasks(Array.isArray(response.data) ? response.data : []);
       } catch (err) {
         console.error("Error fetching tasks:", err);
@@ -39,30 +44,171 @@ const TaskList = ({ refreshTrigger }) => {
     fetchTasks();
   }, [uid, refreshTrigger]); // Refetches when auth/task state changes
 
+  const confirmDeleteTask = async (taskId) => {
+    if (!uid || !taskId) return;
+
+    try {
+      setDeletingTaskId(taskId);
+      await axios.delete(`http://127.0.0.1:5000/tasks/${taskId}`, {
+        params: { userId: uid }
+      });
+
+      setTasks((prev) => prev.filter((task) => task.id !== taskId));
+    } catch (err) {
+      console.error('Error deleting task:', err);
+      alert('Could not delete task. Please try again.');
+    } finally {
+      setDeletingTaskId(null);
+      setConfirmingTaskId(null);
+    }
+  };
+
+  const toggleTaskDetails = (taskId) => {
+    setExpandedTaskIds((prev) => ({
+      ...prev,
+      [taskId]: !prev[taskId]
+    }));
+  };
+
+  const toggleTaskCompletion = async (task) => {
+    if (!uid || !task.id) return;
+
+    try {
+      const newStatus = task.status === 'completed' ? 'pending' : 'completed';
+      await axios.patch(`http://127.0.0.1:5000/users/${uid}/tasks/${task.id}`, {
+        userId: uid,
+        status: newStatus
+      });
+
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.id === task.id ? { ...t, status: newStatus } : t
+        )
+      );
+    } catch (err) {
+      console.error('Error updating task status:', err);
+      alert('Could not update task status. Please try again.');
+    }
+  };
+
+  // Filter tasks based on active tab
+  const filteredTasks = tasks.filter((task) => {
+    if (activeTab === 'completed') {
+      return task.status === 'completed';
+    } else {
+      return task.status !== 'completed';
+    }
+  });
+
   return (
     <div className="task-list">
-      {tasks.length > 0 ? (
-        tasks.map(task => (
-          <div key={task.id} className="task-item">
-            <h4>{task.title}</h4>
-            <p>{task.description || ""}</p>
-            <small>Due: {task.dueDate}</small>
-            <br />
-            <small>
-              Priority: {task.priority || 'medium'} • Visibility: {(task.isPublic || task.visibility === 'public') ? 'Public' : 'Private'}
-            </small>
-            {Array.isArray(task.tags) && task.tags.length > 0 && (
-              <>
-                <br />
-                <small>Tags: {task.tags.join(', ')}</small>
-              </>
+      {/* Tabs for filtering */}
+      <div className="task-list-tabs">
+        <button
+          className={`task-list-tab ${activeTab === 'uncompleted' ? 'active' : ''}`}
+          onClick={() => setActiveTab('uncompleted')}
+        >
+          Uncompleted
+        </button>
+        <button
+          className={`task-list-tab ${activeTab === 'completed' ? 'active' : ''}`}
+          onClick={() => setActiveTab('completed')}
+        >
+          Completed
+        </button>
+      </div>
+
+      {loading && <p>Loading tasks...</p>}
+      {filteredTasks.length > 0 ? (
+        filteredTasks.map(task => (
+          <div key={task.id} className="task-item task-item-with-confirmation">
+            <div className={`task-item-content ${confirmingTaskId === task.id ? 'task-item-obscured' : ''}`}>
+              <div className="task-item-header-row">
+                <div className="task-item-checkbox-wrapper">
+                  <input
+                    type="checkbox"
+                    className="task-item-checkbox"
+                    checked={task.status === 'completed'}
+                    onChange={() => toggleTaskCompletion(task)}
+                    disabled={deletingTaskId === task.id}
+                  />
+                </div>
+
+                <div className="task-item-summary">
+                  <h4>{task.title}</h4>
+                  <small>Due: {task.dueDate}</small>
+                </div>
+
+                <div className="task-item-actions">
+                  <button
+                    type="button"
+                    className="task-details-button"
+                    onClick={() => toggleTaskDetails(task.id)}
+                    disabled={deletingTaskId === task.id}
+                  >
+                    {expandedTaskIds[task.id] ? 'Hide Details' : 'Show Details'}
+                  </button>
+
+                  {confirmingTaskId !== task.id && (
+                    <button
+                      type="button"
+                      className="delete-task-button"
+                      onClick={() => setConfirmingTaskId(task.id)}
+                      disabled={deletingTaskId === task.id}
+                    >
+                      {deletingTaskId === task.id ? 'Deleting...' : 'Delete Task'}
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {expandedTaskIds[task.id] && (
+                <div className="task-item-details">
+                  <p>{task.description || "No description."}</p>
+                  {Array.isArray(task.tags) && task.tags.length > 0 ? (
+                    <small>Tags: {task.tags.join(', ')}</small>
+                  ) : (
+                    <small>Tags: None</small>
+                  )}
+                </div>
+              )}
+
+            </div>
+
+            {confirmingTaskId === task.id && (
+              <div className="task-delete-confirmation-overlay">
+                <p>Are you sure you want to delete this task?</p>
+                <div className="task-delete-confirmation-actions">
+                  <button
+                    type="button"
+                    className="delete-task-button confirm-yes"
+                    onClick={() => confirmDeleteTask(task.id)}
+                    disabled={deletingTaskId === task.id}
+                  >
+                    {deletingTaskId === task.id ? 'Deleting...' : 'Yes'}
+                  </button>
+                  <button
+                    type="button"
+                    className="delete-task-button confirm-no"
+                    onClick={() => setConfirmingTaskId(null)}
+                    disabled={deletingTaskId === task.id}
+                  >
+                    No
+                  </button>
+                </div>
+              </div>
             )}
           </div>
         ))
       ) : (
         /* No tasks state on the dashboard */
         <div className="empty-tasks">
-          <p>No upcoming tasks. Enjoy your free time, Gator!</p>
+          
+          <p>
+            {activeTab === 'completed'
+              ? 'No completed tasks. Get started with uncompleted tasks!'
+              : 'No upcoming tasks. Enjoy your free time!'}
+          </p>
         </div>
       )}
     </div>

--- a/frontend/src/components/TaskList.js
+++ b/frontend/src/components/TaskList.js
@@ -30,8 +30,18 @@ const TaskList = ({ refreshTrigger }) => {
         tasks.map(task => (
           <div key={task.id} className="task-item">
             <h4>{task.title}</h4>
-            <p>{task.description}</p>
+            <p>{task.description || ""}</p>
             <small>Due: {task.dueDate}</small>
+            <br />
+            <small>
+              Priority: {task.priority || 'medium'} • Visibility: {(task.isPublic || task.visibility === 'public') ? 'Public' : 'Private'}
+            </small>
+            {Array.isArray(task.tags) && task.tags.length > 0 && (
+              <>
+                <br />
+                <small>Tags: {task.tags.join(', ')}</small>
+              </>
+            )}
           </div>
         ))
       ) : (

--- a/frontend/src/components/TaskList.js
+++ b/frontend/src/components/TaskList.js
@@ -1,28 +1,43 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { auth } from '../firebase';
+import { onAuthStateChanged } from 'firebase/auth';
 
 const TaskList = ({ refreshTrigger }) => {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [uid, setUid] = useState(null);
 
   useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setUid(user?.uid || null);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (!uid) {
+      setTasks([]);
+      setLoading(false);
+      return;
+    }
+
     const fetchTasks = async () => {
-      const user = auth.currentUser;
-      if (user) {
-        try {
-          // Fetching sorted/limited tasks from your Flask API
-          const response = await axios.get(`http://127.0.0.1:5000/tasks/${user.uid}?limit=10`);
-          setTasks(response.data);
-        } catch (err) {
-          console.error("Error fetching tasks:", err);
-        } finally {
-          setLoading(false); // Stop loading regardless of success/fail
-        }
+      try {
+        // Fetching sorted/limited tasks from your Flask API
+        const response = await axios.get(`http://127.0.0.1:5000/tasks/${uid}?limit=10`);
+        setTasks(Array.isArray(response.data) ? response.data : []);
+      } catch (err) {
+        console.error("Error fetching tasks:", err);
+      } finally {
+        setLoading(false); // Stop loading regardless of success/fail
       }
     };
+
+    setLoading(true);
     fetchTasks();
-  }, [refreshTrigger]); // Refetches when a task is added
+  }, [uid, refreshTrigger]); // Refetches when auth/task state changes
 
   return (
     <div className="task-list">

--- a/frontend/src/components/task-components/TaskForm.js
+++ b/frontend/src/components/task-components/TaskForm.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'; 
 import axios from 'axios'; // allows React front-end to interact with the back-end
-import { auth } from '../firebase';
+import { auth } from '../../firebase';
 
 const TaskForm = ({ onTaskAdded }) => {
     const [title, setTitle]      = useState('');

--- a/frontend/src/components/task-components/TaskForm.js
+++ b/frontend/src/components/task-components/TaskForm.js
@@ -33,7 +33,7 @@ const TaskForm = ({ onTaskAdded }) => {
         };
 
         try{
-            await axios.post('http://127.0.0.1:5000/tasks', newTask);
+            await axios.post(`http://127.0.0.1:5000/users/${user.uid}/tasks`, newTask);
             setTitle("");
             setDueDate("");
             setPriority('medium');

--- a/frontend/src/components/task-components/TaskListPage.js
+++ b/frontend/src/components/task-components/TaskListPage.js
@@ -1,0 +1,5 @@
+// This is a whole webpage dedicated to displaying a user's ENTIRE list of tasks
+// For simplicity, we will not implement pagination or filtering here, but it can be added in the future
+import TaskForm from "./TaskForm";
+import TaskList from "../TaskList";
+

--- a/frontend/src/styles/Login.css
+++ b/frontend/src/styles/Login.css
@@ -95,7 +95,27 @@
   transition: border-color 0.2s;
 }
 
+.auth-page-layout select,
+.auth-page-layout textarea {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-sizing: border-box;
+  font-size: 0.95rem;
+  font-family: "Oswald", sans-serif;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
 .auth-page-layout input:focus {
+  border-color: #7c5cfc;
+}
+
+.auth-page-layout select:focus,
+.auth-page-layout textarea:focus {
   border-color: #7c5cfc;
 }
 

--- a/frontend/src/styles/TaskRelatedStyles.css
+++ b/frontend/src/styles/TaskRelatedStyles.css
@@ -1,0 +1,167 @@
+.task-item-with-confirmation {
+	position: relative;
+}
+
+.task-list-tabs {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 20px;
+	border-bottom: 2px solid #e5e5e5;
+}
+
+.task-list-tab {
+	padding: 10px 16px;
+	background: none;
+	border: none;
+	border-bottom: 3px solid transparent;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.95rem;
+	font-weight: 500;
+	color: #6b7280;
+	cursor: pointer;
+	transition: all 0.2s ease;
+}
+
+.task-list-tab:hover {
+	color: #374151;
+}
+
+.task-list-tab.active {
+	color: #7c5cfc;
+	border-bottom-color: #7c5cfc;
+}
+
+.task-item-content {
+	transition: filter 0.2s ease, opacity 0.2s ease;
+}
+
+.task-item-header-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: 12px;
+}
+
+.task-item-checkbox-wrapper {
+	display: flex;
+	align-items: center;
+	margin-top: 2px;
+}
+
+.task-item-checkbox {
+	width: 20px;
+	height: 20px;
+	cursor: pointer;
+	accent-color: #7c5cfc;
+}
+
+.task-item-summary h4 {
+	margin: 0 0 4px 0;
+}
+
+.task-item-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.task-details-button {
+	display: inline-block;
+	margin-top: 10px;
+	padding: 8px 12px;
+	background-color: #7c5cfc;
+	color: #fff;
+	border: none;
+	border-radius: 8px;
+	font-size: 0.85rem;
+	font-family: "Oswald", sans-serif;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+.task-details-button:hover {
+	background-color: #6a4ae8;
+}
+
+.task-details-button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.task-item-details {
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px solid #eee;
+}
+
+.task-item-details p {
+	margin: 0 0 6px 0;
+}
+
+.task-item-obscured {
+	filter: blur(1.5px);
+	opacity: 0.4;
+	pointer-events: none;
+}
+
+.task-delete-confirmation-overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 10px;
+	background: rgba(255, 255, 255, 0.65);
+	border-radius: 10px;
+	padding: 12px;
+	text-align: center;
+	z-index: 2;
+}
+
+.task-delete-confirmation-overlay p {
+	margin: 0;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.95rem;
+}
+
+.task-delete-confirmation-actions {
+	display: flex;
+	gap: 8px;
+}
+
+.delete-task-button {
+	display: inline-block;
+	margin-top: 10px;
+	padding: 8px 12px;
+	background-color: #ff4d4d;
+	color: #fff;
+	border: none;
+	border-radius: 8px;
+	font-size: 0.85rem;
+	font-family: "Oswald", sans-serif;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+.confirm-yes,
+.confirm-no {
+	margin-top: 0;
+}
+
+.confirm-no {
+	background-color: #6b7280;
+}
+
+.confirm-no:hover {
+	background-color: #4b5563;
+}
+
+.delete-task-button:hover {
+	background-color: #cc0000;
+}
+
+.delete-task-button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}


### PR DESCRIPTION
This branch includes a variety of changes and additions, some of which include:

- expanded task form to submit new tasks with descriptions, privacy status, and tags
- added ability to see the details of a post
- added ability to delete a post, which deletes it from the users account in the database as well
- updated backend logic so that now each user in the user collection has its own task collection, which stores all of their tasks
- setting up the logic for when user creates or changes the privacy of their task to be public, therefore creating a post on the website
- Added a new file which will contain all the CSS styles related to tasks, to make it easier to navigate the files  

**Task Creation Tab**
<img width="592" height="735" alt="image" src="https://github.com/user-attachments/assets/011cbeda-831d-4ce5-90d9-b88e23bbf900" />

**Task List**
<img width="711" height="260" alt="image" src="https://github.com/user-attachments/assets/2be52989-2031-47a9-85d7-12f1702e6208" />

I will begin working on the dedicated task page, where the user will be able to see all of their tasks, both completed and not completed