### PR TITLE
Public Posts and Tag Usage (+ Other Features)

### DIFF
--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 
 from flask import Flask, g, jsonify, request
@@ -72,6 +72,55 @@ def build_joined_user(uid):
         "school": profile.get("school"),
         "joinedAt": datetime.now(timezone.utc).isoformat(),
     }
+
+
+def build_public_expiration(status, existing_expires_at=None):
+    normalized_status = str(status or "").strip().lower()
+
+    if normalized_status == "completed":
+        if existing_expires_at:
+            return existing_expires_at
+        return (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
+
+    return None
+
+
+def parse_iso_datetime(value):
+    if not value or not isinstance(value, str):
+        return None
+
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return None
+
+
+def is_public_task_expired(task_data):
+    expires_at = parse_iso_datetime((task_data or {}).get("publicExpiresAt"))
+    if not expires_at:
+        return False
+    return datetime.now(timezone.utc) >= expires_at
+
+
+def delete_expired_public_task(task_id, task_data):
+    owner_id = (task_data or {}).get("userId")
+    public_tasks.document(task_id).delete()
+
+    if owner_id:
+        owner_task_ref = get_user_task_ref(owner_id, task_id)
+        owner_task_snapshot = owner_task_ref.get()
+        if getattr(owner_task_snapshot, "exists", False):
+            owner_task_ref.set({
+                "visibility": "private",
+                "isPublic": False,
+                "peopleNeeded": None,
+                "joinedUsers": [],
+                "publicExpiresAt": None,
+            }, merge=True)
 
 
 def sync_public_task(task_id, task_data):
@@ -449,6 +498,15 @@ def update_task(uid, task_id):
             updates["peopleNeeded"] = None
             updates["joinedUsers"] = []
 
+    next_status = updates.get("status", current_task.get("status"))
+    next_public_flag = updates.get("isPublic", current_task.get("isPublic"))
+    current_public_expires_at = current_task.get("publicExpiresAt")
+    next_public_expires_at = build_public_expiration(next_status, current_public_expires_at)
+    if next_public_flag:
+        updates["publicExpiresAt"] = next_public_expires_at
+    else:
+        updates["publicExpiresAt"] = None
+
     if not updates:
         return jsonify({"error": "No valid fields to update"}), 400
 
@@ -562,6 +620,9 @@ def update_public_task(task_id):
             return jsonify({"error": people_needed_error}), 400
         updates["peopleNeeded"] = people_needed
 
+    next_status = updates.get("status", current_task.get("status"))
+    updates["publicExpiresAt"] = build_public_expiration(next_status, current_task.get("publicExpiresAt"))
+
     task_ref.set(updates, merge=True)
 
     updated_task = current_task | updates
@@ -572,7 +633,12 @@ def update_public_task(task_id):
 def get_public_tasks():
     task_list = []
     for task in public_tasks.stream():
-        task_list.append(task.to_dict() | {"id": task.id})
+        task_data = task.to_dict() or {}
+        if is_public_task_expired(task_data):
+            delete_expired_public_task(task.id, task_data)
+            continue
+
+        task_list.append(task_data | {"id": task.id})
     return jsonify(task_list)
 
 
@@ -594,12 +660,18 @@ def join_public_task(task_id):
     public_task = public_snapshot.to_dict() or {}
     owner_id = public_task.get("userId")
 
+    if is_public_task_expired(public_task):
+        delete_expired_public_task(task_id, public_task)
+        return jsonify({"error": "Public task is no longer available"}), 410
+
     if not public_task.get("isPublic", False):
         return jsonify({"error": "Task is not public"}), 400
     if not owner_id:
         return jsonify({"error": "Task owner is missing"}), 400
     if owner_id == user_id:
         return jsonify({"error": "You cannot join your own public task"}), 400
+    if str(public_task.get("status", "")).strip().lower() == "completed":
+        return jsonify({"error": "This task is completed and can no longer be joined"}), 409
 
     joined_users = public_task.get("joinedUsers")
     if not isinstance(joined_users, list):

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from functools import wraps
 
 from flask import Flask, g, jsonify, request
@@ -60,6 +61,17 @@ def normalize_people_needed(raw_people_needed):
         return None, "peopleNeeded must be between 1 and 10"
 
     return people_needed, None
+
+
+def build_joined_user(uid):
+    profile = get_user_public_profile(uid) or {}
+    return {
+        "uid": uid,
+        "displayName": profile.get("displayName"),
+        "email": profile.get("email"),
+        "school": profile.get("school"),
+        "joinedAt": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 def sync_public_task(task_id, task_data):
@@ -192,10 +204,14 @@ def update_user_profile(uid):
     if not updates:
         return jsonify({"error": "No valid profile fields to update."}), 400
 
-    updates["updatedAt"] = firestore.SERVER_TIMESTAMP
-
     try:
         user_ref = db.collection('users').document(uid)
+        user_doc = user_ref.get()
+
+        if not getattr(user_doc, "exists", False):
+            updates["createdAt"] = firestore.SERVER_TIMESTAMP
+
+        updates["updatedAt"] = firestore.SERVER_TIMESTAMP
         user_ref.set(updates, merge=True)
         return jsonify({"message": "Profile updated"}), 200
     except Exception as e:
@@ -345,6 +361,7 @@ def add_task(uid):
         "visibility": "public" if is_public else "private",
         "isPublic": is_public,
         "peopleNeeded": people_needed if is_public else None,
+        "joinedUsers": [],
         "tags": tags,
         "status": "pending",
         "createdAt": firestore.SERVER_TIMESTAMP
@@ -485,6 +502,7 @@ def add_public_task():
         "visibility": "public",
         "isPublic": True,
         "peopleNeeded": people_needed,
+        "joinedUsers": [],
         "tags": tags,
         "status": "pending",
         "createdAt": firestore.SERVER_TIMESTAMP
@@ -555,6 +573,102 @@ def get_public_tasks():
     for task in public_tasks.stream():
         task_list.append(task.to_dict() | {"id": task.id})
     return jsonify(task_list)
+
+
+@app.route('/public_tasks/<task_id>/join', methods=['POST'])
+def join_public_task(task_id):
+    data = parse_payload()
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body."}), 400
+
+    user_id = data.get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    public_task_ref = public_tasks.document(task_id)
+    public_snapshot = public_task_ref.get()
+    if not getattr(public_snapshot, "exists", False):
+        return jsonify({"error": "Public task not found"}), 404
+
+    public_task = public_snapshot.to_dict() or {}
+    owner_id = public_task.get("userId")
+
+    if not public_task.get("isPublic", False):
+        return jsonify({"error": "Task is not public"}), 400
+    if not owner_id:
+        return jsonify({"error": "Task owner is missing"}), 400
+    if owner_id == user_id:
+        return jsonify({"error": "You cannot join your own public task"}), 400
+
+    joined_users = public_task.get("joinedUsers")
+    if not isinstance(joined_users, list):
+        joined_users = []
+
+    if any((isinstance(joined, dict) and joined.get("uid") == user_id) for joined in joined_users):
+        return jsonify({"error": "You have already joined this public task"}), 409
+
+    people_needed = public_task.get("peopleNeeded")
+    if isinstance(people_needed, int) and people_needed > 0 and len(joined_users) >= people_needed:
+        return jsonify({"error": "This task is already full"}), 409
+
+    updated_joined_users = [*joined_users, build_joined_user(user_id)]
+    updates = {"joinedUsers": updated_joined_users}
+
+    public_task_ref.set(updates, merge=True)
+
+    owner_task_ref = get_user_task_ref(owner_id, task_id)
+    owner_task_snapshot = owner_task_ref.get()
+    if getattr(owner_task_snapshot, "exists", False):
+        owner_task_ref.set(updates, merge=True)
+
+    updated_task = public_task | updates
+    return jsonify({"message": "Joined task", "task": updated_task}), 200
+
+
+@app.route('/public_tasks/<task_id>/leave', methods=['POST'])
+def leave_public_task(task_id):
+    data = parse_payload()
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body."}), 400
+
+    user_id = data.get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    public_task_ref = public_tasks.document(task_id)
+    public_snapshot = public_task_ref.get()
+    if not getattr(public_snapshot, "exists", False):
+        return jsonify({"error": "Public task not found"}), 404
+
+    public_task = public_snapshot.to_dict() or {}
+    owner_id = public_task.get("userId")
+
+    if owner_id == user_id:
+        return jsonify({"error": "Task owner cannot leave their own public task"}), 400
+
+    joined_users = public_task.get("joinedUsers")
+    if not isinstance(joined_users, list):
+        joined_users = []
+
+    if not any((isinstance(joined, dict) and joined.get("uid") == user_id) for joined in joined_users):
+        return jsonify({"error": "You have not joined this public task"}), 409
+
+    updated_joined_users = [
+        joined
+        for joined in joined_users
+        if not (isinstance(joined, dict) and joined.get("uid") == user_id)
+    ]
+    updates = {"joinedUsers": updated_joined_users}
+
+    public_task_ref.set(updates, merge=True)
+
+    owner_task_ref = get_user_task_ref(owner_id, task_id)
+    owner_task_snapshot = owner_task_ref.get()
+    if getattr(owner_task_snapshot, "exists", False):
+        owner_task_ref.set(updates, merge=True)
+
+    updated_task = public_task | updates
+    return jsonify({"message": "Left task", "task": updated_task}), 200
 
 @app.route('/public_tasks/<task_id>', methods=['DELETE'])
 def delete_public_task(task_id):

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 
@@ -11,6 +12,7 @@ from firebase_config import db
 app = Flask(__name__)
 CORS(app)
 public_tasks = db.collection('public_tasks')
+task_tag_catalog = db.collection('task_tag_catalog')
 
 
 def parse_payload():
@@ -32,6 +34,19 @@ def normalize_tags(raw_tags):
     if isinstance(raw_tags, list):
         return [str(tag).strip() for tag in raw_tags if str(tag).strip()]
     return []
+
+
+def normalize_tag_name(raw_tag):
+    if raw_tag is None:
+        return None
+
+    tag = str(raw_tag).strip().lower()
+    if not tag:
+        return None
+
+    tag = re.sub(r"\s+", "-", tag)
+    tag = re.sub(r"[^a-z0-9\-_]", "", tag)
+    return tag[:40] or None
 
 
 def normalize_due_date(raw_due_date):
@@ -265,6 +280,79 @@ def update_user_profile(uid):
         return jsonify({"message": "Profile updated"}), 200
     except Exception as e:
         return jsonify({"error": str(e)}), 400
+
+
+@app.route('/task_tags', methods=['GET'])
+def get_task_tags():
+    try:
+        tag_set = {}
+
+        for tag_doc in task_tag_catalog.stream():
+            tag_data = tag_doc.to_dict() or {}
+            normalized_tag = normalize_tag_name(tag_data.get("name") or tag_doc.id)
+            if normalized_tag:
+                tag_set[normalized_tag] = True
+
+        tags = sorted(tag_set.keys())
+        return jsonify(tags), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@app.route('/task_tags', methods=['POST'])
+def add_task_tag():
+    data = parse_payload()
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid or missing request body."}), 400
+
+    user_id = data.get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    user_doc = db.collection('users').document(user_id).get()
+    user_data = user_doc.to_dict() or {}
+    if not user_data.get("isAdmin"):
+        return jsonify({"error": "Only admins can add tags"}), 403
+
+    tag_name = normalize_tag_name(data.get("tag"))
+    if not tag_name:
+        return jsonify({"error": "tag is required"}), 400
+
+    task_tag_catalog.document(tag_name).set({
+        "name": tag_name,
+        "createdBy": user_id,
+        "createdAt": firestore.SERVER_TIMESTAMP,
+    }, merge=True)
+
+    return jsonify({"message": "Tag added", "tag": tag_name}), 201
+
+
+@app.route('/task_tags/<tag_name>', methods=['DELETE'])
+def delete_task_tag(tag_name):
+    normalized_tag = normalize_tag_name(tag_name)
+    if not normalized_tag:
+        return jsonify({"error": "Valid tag name is required"}), 400
+
+    user_id = request.args.get("userId")
+    if not user_id:
+        data = parse_payload()
+        if isinstance(data, dict):
+            user_id = data.get("userId")
+    if not user_id:
+        return jsonify({"error": "userId is required"}), 400
+
+    user_doc = db.collection('users').document(user_id).get()
+    user_data = user_doc.to_dict() or {}
+    if not user_data.get("isAdmin"):
+        return jsonify({"error": "Only admins can delete tags"}), 403
+
+    tag_ref = task_tag_catalog.document(normalized_tag)
+    tag_doc = tag_ref.get()
+    if not getattr(tag_doc, "exists", False):
+        return jsonify({"error": "Tag not found"}), 404
+
+    tag_ref.delete()
+    return jsonify({"message": "Tag deleted", "tag": normalized_tag}), 200
 
 
 @app.route('/reports', methods=['POST'])

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -447,6 +447,7 @@ def update_task(uid, task_id):
         updates["visibility"] = "public" if next_public else "private"
         if not next_public:
             updates["peopleNeeded"] = None
+            updates["joinedUsers"] = []
 
     if not updates:
         return jsonify({"error": "No valid fields to update"}), 400

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import ProfilePage from "./components/ProfilePage";
 import ModerationPage from "./components/ModerationPage";
 import FriendsPage from "./components/FriendsPage";
 import TaskListPage from "./components/task-components/TaskListPage";
+import PublicTasksPage from "./components/task-components/PublicTasksPage";
 import "./styles/Home.css";
 import ProtectedRoute from "./components/ProtectedRoute";
 
@@ -117,6 +118,19 @@ function App() {
                 <NavBar user={currentUser} />
                 <div style={{ marginLeft: "60px", flex: 1 }}>
                   <TaskListPage />
+                </div>
+              </div>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/public-tasks"
+          element={
+            <ProtectedRoute user={currentUser} authLoading={authLoading}>
+              <div style={{ display: "flex" }}>
+                <NavBar user={currentUser} />
+                <div style={{ marginLeft: "60px", flex: 1 }}>
+                  <PublicTasksPage />
                 </div>
               </div>
             </ProtectedRoute>

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -16,6 +16,16 @@ const Dashboard = () => {
     const [showCreateTaskPopup, setShowCreateTaskPopup] = useState(false);
     const [myPublicTasks, setMyPublicTasks] = useState([]);
     const [loadingMyPublicTasks, setLoadingMyPublicTasks] = useState(false);
+    const [editingPublicTask, setEditingPublicTask] = useState(null);
+    const [savingPublicTask, setSavingPublicTask] = useState(false);
+    const [editPublicForm, setEditPublicForm] = useState({
+        title: "",
+        dueDate: "",
+        priority: "medium",
+        description: "",
+        visibility: "public",
+        peopleNeeded: "",
+    });
 
     useEffect(()=> {
         const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -73,6 +83,122 @@ const Dashboard = () => {
     const handleTaskAdded = () => {
         setRefresh(prev => prev + 1); // Increment to trigger useEffect in TaskList
         setShowCreateTaskPopup(false);
+    };
+
+    const openPublicTaskEditModal = (task) => {
+        if (!task?.id) return;
+
+        setEditingPublicTask(task);
+        setEditPublicForm({
+            title: task.title || "",
+            dueDate: task.dueDate || "",
+            priority: task.priority || "medium",
+            description: task.description || "",
+            visibility: task.visibility || (task.isPublic ? "public" : "private"),
+            peopleNeeded: Number.isInteger(task.peopleNeeded) ? String(task.peopleNeeded) : "",
+        });
+    };
+
+    const closePublicTaskEditModal = () => {
+        if (savingPublicTask) return;
+        setEditingPublicTask(null);
+        setEditPublicForm({
+            title: "",
+            dueDate: "",
+            priority: "medium",
+            description: "",
+            visibility: "public",
+            peopleNeeded: "",
+        });
+    };
+
+    const handlePublicTaskEditSubmit = async (event) => {
+        event.preventDefault();
+        if (!authUser?.uid || !editingPublicTask?.id || savingPublicTask) return;
+
+        const nextTitle = String(editPublicForm.title || "").trim();
+        if (!nextTitle) {
+            alert("Task title cannot be empty.");
+            return;
+        }
+
+        const normalizedPriority = String(editPublicForm.priority || "medium").trim().toLowerCase();
+        if (!["low", "medium", "high"].includes(normalizedPriority)) {
+            alert("Priority must be low, medium, or high.");
+            return;
+        }
+
+        const normalizedDueDate = String(editPublicForm.dueDate || "").trim() || null;
+        const normalizedDescription = String(editPublicForm.description || "");
+        const titleChanged = nextTitle !== String(editingPublicTask.title || "").trim();
+        const nextVisibility = editPublicForm.visibility === "public" ? "public" : "private";
+        const renameForcesPrivate = Boolean(editingPublicTask.isPublic && titleChanged);
+        const switchedPublicToPrivate = Boolean(editingPublicTask.isPublic && nextVisibility === "private");
+        const willDisbandPublicPost = renameForcesPrivate || switchedPublicToPrivate;
+        const finalVisibility = renameForcesPrivate ? "private" : nextVisibility;
+
+        let nextPeopleNeeded = null;
+        if (finalVisibility === "public") {
+            const parsedPeopleNeeded = Number(String(editPublicForm.peopleNeeded || "").trim());
+            if (!Number.isInteger(parsedPeopleNeeded) || parsedPeopleNeeded < 1 || parsedPeopleNeeded > 10) {
+                alert("People needed must be a whole number between 1 and 10.");
+                return;
+            }
+            nextPeopleNeeded = parsedPeopleNeeded;
+        }
+
+        if (willDisbandPublicPost) {
+            const confirmed = window.confirm(
+                "Warning: This change will make the post private and disband the current group (remove joined users). Continue?"
+            );
+            if (!confirmed) return;
+        }
+
+        const payload = {
+            userId: authUser.uid,
+            title: nextTitle,
+            description: normalizedDescription,
+            dueDate: normalizedDueDate,
+            priority: normalizedPriority,
+            visibility: finalVisibility,
+            isPublic: finalVisibility === "public",
+            peopleNeeded: finalVisibility === "public" ? nextPeopleNeeded : null,
+        };
+
+        try {
+            setSavingPublicTask(true);
+            await axios.patch(`http://127.0.0.1:5000/users/${authUser.uid}/tasks/${editingPublicTask.id}`, payload);
+
+            setMyPublicTasks((prev) => {
+                if (finalVisibility !== "public") {
+                    return prev.filter((task) => task.id !== editingPublicTask.id);
+                }
+
+                return prev.map((task) =>
+                    task.id === editingPublicTask.id
+                        ? {
+                            ...task,
+                            title: nextTitle,
+                            description: normalizedDescription,
+                            dueDate: normalizedDueDate,
+                            priority: normalizedPriority,
+                            visibility: finalVisibility,
+                            isPublic: true,
+                            peopleNeeded: nextPeopleNeeded,
+                            ...(willDisbandPublicPost ? { joinedUsers: [] } : {}),
+                        }
+                        : task
+                );
+            });
+
+            setRefresh((prev) => prev + 1);
+            closePublicTaskEditModal();
+        } catch (error) {
+            console.error("Error editing public post:", error);
+            alert("Could not edit this public post. Please try again.");
+        } finally {
+            setSavingPublicTask(false);
+        }
     };
 
     const welcomeName =
@@ -149,6 +275,16 @@ const Dashboard = () => {
                                                 {task.dueDate ? ` • Due ${task.dueDate}` : ""}
                                             </small>
 
+                                            <div className="my-public-task-actions">
+                                                <button
+                                                    type="button"
+                                                    className="task-edit-save"
+                                                    onClick={() => openPublicTaskEditModal(task)}
+                                                >
+                                                    Edit Post
+                                                </button>
+                                            </div>
+
                                             <div className="joined-users-block">
                                                 <strong>Joined users:</strong>
                                                 {joinedUsers.length === 0 ? (
@@ -195,6 +331,126 @@ const Dashboard = () => {
                 <button className="logout-button" onClick={handleLogout}>
                     Logout
                 </button>
+
+                {editingPublicTask && (
+                    <div className="tasks-modal-overlay" onClick={closePublicTaskEditModal}>
+                        <div className="tasks-modal-content task-edit-modal" onClick={(event) => event.stopPropagation()}>
+                            <button
+                                type="button"
+                                className="tasks-modal-close"
+                                onClick={closePublicTaskEditModal}
+                                aria-label="Close edit public post modal"
+                            >
+                                ✕
+                            </button>
+
+                            <h3>Edit Public Post</h3>
+                            <form className="task-edit-form" onSubmit={handlePublicTaskEditSubmit}>
+                                <label>
+                                    Task Name
+                                    <input
+                                        type="text"
+                                        value={editPublicForm.title}
+                                        onChange={(event) =>
+                                            setEditPublicForm((prev) => ({ ...prev, title: event.target.value }))
+                                        }
+                                        required
+                                    />
+                                </label>
+
+                                <label>
+                                    Due Date
+                                    <input
+                                        type="date"
+                                        value={editPublicForm.dueDate || ""}
+                                        onChange={(event) =>
+                                            setEditPublicForm((prev) => ({ ...prev, dueDate: event.target.value }))
+                                        }
+                                    />
+                                </label>
+
+                                <label>
+                                    Priority
+                                    <select
+                                        className={`priority-select priority-underlined priority-${editPublicForm.priority || "medium"}`}
+                                        value={editPublicForm.priority}
+                                        onChange={(event) =>
+                                            setEditPublicForm((prev) => ({ ...prev, priority: event.target.value }))
+                                        }
+                                    >
+                                        <option value="low" className="priority-option">Low</option>
+                                        <option value="medium" className="priority-option">Medium</option>
+                                        <option value="high" className="priority-option">High</option>
+                                    </select>
+                                </label>
+
+                                <label>
+                                    Description
+                                    <textarea
+                                        rows={4}
+                                        value={editPublicForm.description}
+                                        onChange={(event) =>
+                                            setEditPublicForm((prev) => ({ ...prev, description: event.target.value }))
+                                        }
+                                    />
+                                </label>
+
+                                <label>
+                                    Visibility
+                                    <select
+                                        value={editPublicForm.visibility}
+                                        onChange={(event) =>
+                                            setEditPublicForm((prev) => ({
+                                                ...prev,
+                                                visibility: event.target.value,
+                                                peopleNeeded:
+                                                    event.target.value === "public"
+                                                        ? (prev.peopleNeeded || "1")
+                                                        : "",
+                                            }))
+                                        }
+                                    >
+                                        <option value="private">Private</option>
+                                        <option value="public">Public (Make it a Post!)</option>
+                                    </select>
+                                </label>
+
+                                {editPublicForm.visibility === "public" && (
+                                    <label>
+                                        People Needed
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            max="10"
+                                            step="1"
+                                            value={editPublicForm.peopleNeeded}
+                                            onChange={(event) =>
+                                                setEditPublicForm((prev) => ({ ...prev, peopleNeeded: event.target.value }))
+                                            }
+                                            placeholder="How many people are needed? (1-10)"
+                                            required
+                                        />
+                                    </label>
+                                )}
+
+                                {editingPublicTask.isPublic && (String(editPublicForm.title || "").trim() !== String(editingPublicTask.title || "").trim() || editPublicForm.visibility === "private") && (
+                                    <p className="task-edit-warning">
+                                        Warning: This change will make the post private and disband the current group.
+                                    </p>
+                                )}
+
+                                <div className="task-edit-actions">
+                                    <button type="button" className="task-edit-cancel" onClick={closePublicTaskEditModal} disabled={savingPublicTask}>
+                                        Cancel
+                                    </button>
+                                    <button type="submit" className="task-edit-save" disabled={savingPublicTask}>
+                                        {savingPublicTask ? "Saving..." : "Save Changes"}
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                )}
             </div> 
         </div>
     );

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import "../styles/Dashboard.css";
 import TaskForm from './task-components/TaskForm';
 import TaskList from './task-components/TaskList';
+import LoadingPage from "./LoadingPage";
 
 
 const Dashboard = () => {
@@ -16,6 +17,7 @@ const Dashboard = () => {
     const [showCreateTaskPopup, setShowCreateTaskPopup] = useState(false);
     const [myPublicTasks, setMyPublicTasks] = useState([]);
     const [loadingMyPublicTasks, setLoadingMyPublicTasks] = useState(false);
+    const [loadingProfile, setLoadingProfile] = useState(true);
     const [editingPublicTask, setEditingPublicTask] = useState(null);
     const [savingPublicTask, setSavingPublicTask] = useState(false);
     const [editPublicForm, setEditPublicForm] = useState({
@@ -33,15 +35,19 @@ const Dashboard = () => {
 
             if (!user) {
                 setUserData(null);
+                setLoadingProfile(false);
                 return;
             }
 
             try {
+                setLoadingProfile(true);
                 const response = await axios.get(`http://127.0.0.1:5000/users/${user.uid}`);
                 setUserData(response.data || null);
             } catch (error) {
                 console.error("Error loading user profile:", error);
                 setUserData(null);
+            } finally {
+                setLoadingProfile(false);
             }
         });
 
@@ -225,6 +231,10 @@ const Dashboard = () => {
             : userData?.school === "SF"
                 ? "Santa Fe College"
                 : userData?.school;
+
+    if (loadingProfile || (authUser?.uid && loadingMyPublicTasks)) {
+        return <LoadingPage message="Loading dashboard..." />;
+    }
     
     return (
         <div className="dashboard-page-wrapper">

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -14,6 +14,8 @@ const Dashboard = () => {
     const navigate = useNavigate();
     const [refresh, setRefresh] = useState(0);
     const [showCreateTaskPopup, setShowCreateTaskPopup] = useState(false);
+    const [myPublicTasks, setMyPublicTasks] = useState([]);
+    const [loadingMyPublicTasks, setLoadingMyPublicTasks] = useState(false);
 
     useEffect(()=> {
         const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -35,6 +37,30 @@ const Dashboard = () => {
 
         return () => unsubscribe();
     }, []);
+
+    useEffect(() => {
+        if (!authUser?.uid) {
+            setMyPublicTasks([]);
+            return;
+        }
+
+        const fetchMyPublicTasks = async () => {
+            try {
+                setLoadingMyPublicTasks(true);
+                const response = await axios.get("http://127.0.0.1:5000/public_tasks");
+                const allPublicTasks = Array.isArray(response.data) ? response.data : [];
+                setMyPublicTasks(allPublicTasks.filter((task) => task.userId === authUser.uid));
+            } catch (error) {
+                console.error("Error loading my public tasks:", error);
+                setMyPublicTasks([]);
+            } finally {
+                setLoadingMyPublicTasks(false);
+            }
+        };
+
+        fetchMyPublicTasks();
+    }, [authUser?.uid, refresh]);
+
     const handleLogout = async () => {
         try {
             await signOut(auth); // Tells Firebase to end the session
@@ -56,6 +82,17 @@ const Dashboard = () => {
         authUser?.email?.split('@')[0] ||
         "Loading...";
 
+    const usernameLabel =
+        userData?.username ||
+        authUser?.email?.split('@')[0] ||
+        authUser?.uid ||
+        "loading";
+
+    const fullNameLabel =
+        userData?.firstName && userData?.lastName
+            ? `${userData.firstName} ${userData.lastName}`
+            : userData?.displayName || authUser?.displayName || welcomeName;
+
     const affiliationLabel =
         userData?.school === "UF"
             ? "University of Florida"
@@ -65,14 +102,17 @@ const Dashboard = () => {
     
     return (
         <div className="dashboard-page-wrapper">
-            <div className="dashboard-layout">   
-                {/* 3. Display the unique profile data */}
-                <h1>Welcome, {welcomeName}!</h1>
-                <p>Affiliation: {affiliationLabel || "Loading..."}</p>
-                
-                {/* Tasks Display Section */}
-                <h3>Tasks</h3>
-                    <section className="tasks-page-section">
+            <div className="dashboard-layout">
+                <section className="dashboard-bubble dashboard-user-bubble">
+                    <h1>Welcome, {welcomeName}!</h1>
+                    <p className="dashboard-name">{fullNameLabel}</p>
+                    <p>Affiliation: {affiliationLabel || "Loading..."}</p>
+                </section>
+
+                <div className="dashboard-bubble-grid">
+                    <section className="dashboard-bubble dashboard-tasks-bubble">
+                        <h3>Tasks</h3>
+                        <section className="tasks-page-section">
                         <button
                             type="button"
                             className="create-task-trigger"
@@ -83,6 +123,53 @@ const Dashboard = () => {
                     </section>
 
                     <TaskList refreshTrigger={refresh} />
+
+                    </section>
+
+                    <section className="dashboard-bubble dashboard-public-tasks-bubble">
+                        <h3>My Public Tasks</h3>
+                        {loadingMyPublicTasks ? (
+                            <p>Loading your public tasks...</p>
+                        ) : myPublicTasks.length === 0 ? (
+                            <p>You haven't created any public tasks yet.</p>
+                        ) : (
+                            <div className="my-public-tasks-list">
+                                {myPublicTasks.map((task) => {
+                                    const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
+                                    const peopleNeeded = Number.isInteger(task.peopleNeeded) ? task.peopleNeeded : null;
+
+                                    return (
+                                        <article key={task.id} className="my-public-task-card">
+                                            <h4>{task.title}</h4>
+                                            <p>{task.description || "No description."}</p>
+                                            <small>
+                                                {peopleNeeded
+                                                    ? `${joinedUsers.length}/${peopleNeeded} joined`
+                                                    : `${joinedUsers.length} joined`}
+                                                {task.dueDate ? ` • Due ${task.dueDate}` : ""}
+                                            </small>
+
+                                            <div className="joined-users-block">
+                                                <strong>Joined users:</strong>
+                                                {joinedUsers.length === 0 ? (
+                                                    <p>No one has joined yet.</p>
+                                                ) : (
+                                                    <ul>
+                                                        {joinedUsers.map((joinedUser) => (
+                                                            <li key={joinedUser.uid || `${task.id}-${joinedUser.email || "unknown"}`}>
+                                                                {joinedUser.displayName || joinedUser.email || joinedUser.uid}
+                                                            </li>
+                                                        ))}
+                                                    </ul>
+                                                )}
+                                            </div>
+                                        </article>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </section>
+                </div>
 
                     {showCreateTaskPopup && (
                         <div
@@ -104,10 +191,6 @@ const Dashboard = () => {
                             </div>
                         </div>
                     )}
-                <hr className="section-divider" />
-                <h3>Public Tasks</h3>
-                
-                <hr className="section-divider" />
                 
                 <button className="logout-button" onClick={handleLogout}>
                     Logout

--- a/frontend/src/components/LoadingPage.js
+++ b/frontend/src/components/LoadingPage.js
@@ -1,0 +1,15 @@
+import React from "react";
+import "../styles/LoadingPage.css";
+
+const LoadingPage = ({ message = "Loading..." }) => {
+  return (
+    <div className="loading-page">
+      <div className="loading-card">
+        <div className="loading-spinner" aria-hidden="true" />
+        <p>{message}</p>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingPage;

--- a/frontend/src/components/ModerationPage.js
+++ b/frontend/src/components/ModerationPage.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import axios from "axios";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../firebase";
 import "../styles/Moderation.css";
 
 const formatCreatedAt = (value) => {
@@ -53,6 +55,13 @@ const ModerationPage = () => {
   const [expandedId, setExpandedId] = useState("");
   const [processingId, setProcessingId] = useState("");
   const [pendingBanReport, setPendingBanReport] = useState(null);
+  const [currentUid, setCurrentUid] = useState("");
+  const [tags, setTags] = useState([]);
+  const [loadingTags, setLoadingTags] = useState(true);
+  const [newTag, setNewTag] = useState("");
+  const [addingTag, setAddingTag] = useState(false);
+  const [deletingTag, setDeletingTag] = useState("");
+  const [tagError, setTagError] = useState("");
 
   const fetchReports = async () => {
     setLoading(true);
@@ -72,6 +81,92 @@ const ModerationPage = () => {
   useEffect(() => {
     fetchReports();
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setCurrentUid(user?.uid || "");
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  const fetchTags = async () => {
+    setLoadingTags(true);
+    setTagError("");
+
+    try {
+      const response = await axios.get("http://127.0.0.1:5000/task_tags");
+      setTags(Array.isArray(response.data) ? response.data : []);
+    } catch (err) {
+      console.error("Error loading task tags:", err);
+      setTagError("Could not load task tags.");
+      setTags([]);
+    } finally {
+      setLoadingTags(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTags();
+  }, []);
+
+  const addGlobalTag = async () => {
+    if (!currentUid || addingTag) {
+      return;
+    }
+
+    const normalizedTag = String(newTag || "").trim().toLowerCase();
+    if (!normalizedTag) {
+      return;
+    }
+
+    setAddingTag(true);
+    setTagError("");
+
+    try {
+      const response = await axios.post("http://127.0.0.1:5000/task_tags", {
+        userId: currentUid,
+        tag: normalizedTag,
+      });
+
+      const createdTag = response?.data?.tag;
+      if (createdTag) {
+        setTags((prev) => (prev.includes(createdTag) ? prev : [...prev, createdTag].sort()));
+      }
+      setNewTag("");
+    } catch (err) {
+      console.error("Error adding global tag:", err);
+      setTagError(err?.response?.data?.error || "Could not add tag.");
+    } finally {
+      setAddingTag(false);
+    }
+  };
+
+  const deleteGlobalTag = async (tag) => {
+    if (!currentUid || !tag || deletingTag) {
+      return;
+    }
+
+    const confirmed = window.confirm(`Delete tag #${tag} from catalog?`);
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingTag(tag);
+    setTagError("");
+
+    try {
+      await axios.delete(`http://127.0.0.1:5000/task_tags/${encodeURIComponent(tag)}`, {
+        params: { userId: currentUid },
+      });
+      setTags((prev) => prev.filter((existingTag) => existingTag !== tag));
+    } catch (err) {
+      console.error("Error deleting global tag:", err);
+      setTagError(err?.response?.data?.error || "Could not delete tag.");
+    } finally {
+      setDeletingTag("");
+    }
+  };
 
   const sortedReports = useMemo(() => {
     const copy = [...reports];
@@ -146,77 +241,128 @@ const ModerationPage = () => {
     <div className="moderation-page-wrapper">
       <div className="moderation-layout">
         <h1>Moderation</h1>
-        <p className="moderation-subtitle">Active reports</p>
+        <p className="moderation-subtitle">Admin controls and report management</p>
 
-        {loading && <p>Loading reports...</p>}
-        {!loading && error && <p className="moderation-error">{error}</p>}
+        <section className="moderation-tag-section">
+          <h2>Task Tag Catalog</h2>
+          <p>Manage global task tags stored in task_tag_catalog.</p>
 
-        {!loading && !error && sortedReports.length === 0 && (
-          <p>No active reports.</p>
-        )}
-
-        {!loading && sortedReports.length > 0 && (
-          <div className="moderation-list">
-            {sortedReports.map((report) => {
-              const isExpanded = expandedId === report.id;
-              const isBusy = processingId === report.id;
-
-              return (
-                <div key={report.id} className="moderation-item">
-                  <div className="moderation-item-header">
-                    <div>
-                      <h3>Report #{report.id.slice(0, 6)}</h3>
-                      <p>Filed: {formatCreatedAt(report.createdAt)}</p>
-                    </div>
-                    <button
-                      type="button"
-                      className="moderation-toggle"
-                      onClick={() => setExpandedId(isExpanded ? "" : report.id)}
-                    >
-                      {isExpanded ? "Hide" : "View"}
-                    </button>
-                  </div>
-
-                  {isExpanded && (
-                    <div className="moderation-details">
-                      <div className="moderation-description">
-                        <strong>Description:</strong>
-                        <p>{report.description || "No description."}</p>
-                      </div>
-
-                      <div className="moderation-people-grid">
-                        <PersonInfo title="Victim" person={report.reporter} />
-                        <PersonInfo
-                          title="Perpetrator"
-                          person={report.accused}
-                        />
-                      </div>
-
-                      <div className="moderation-actions">
-                        <button
-                          type="button"
-                          className="close-report-button"
-                          onClick={() => closeReport(report.id)}
-                          disabled={isBusy}
-                        >
-                          {isBusy ? "Processing..." : "Close Report"}
-                        </button>
-                        <button
-                          type="button"
-                          className="ban-user-button"
-                          onClick={() => openBanConfirmation(report)}
-                          disabled={isBusy}
-                        >
-                          {isBusy ? "Processing..." : "Ban User"}
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+          <div className="moderation-tag-add-row">
+            <input
+              type="text"
+              value={newTag}
+              placeholder="new-tag"
+              onChange={(event) => setNewTag(event.target.value)}
+            />
+            <button
+              type="button"
+              className="moderation-tag-add-button"
+              onClick={addGlobalTag}
+              disabled={addingTag || !currentUid}
+            >
+              {addingTag ? "Adding..." : "Add Tag"}
+            </button>
           </div>
-        )}
+
+          {tagError && <p className="moderation-error">{tagError}</p>}
+
+          {loadingTags ? (
+            <p>Loading tags...</p>
+          ) : tags.length === 0 ? (
+            <p>No tags yet. Add your first tag above.</p>
+          ) : (
+            <div className="moderation-tag-list">
+              {tags.map((tag) => (
+                <span key={tag} className="moderation-tag-chip">
+                  <span>#{tag}</span>
+                  <button
+                    type="button"
+                    className="moderation-tag-delete"
+                    onClick={() => deleteGlobalTag(tag)}
+                    disabled={deletingTag === tag || addingTag || !currentUid}
+                    aria-label={`Delete ${tag}`}
+                  >
+                    x
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="moderation-reports-section">
+          <h2>Active Reports</h2>
+
+          {loading && <p>Loading reports...</p>}
+          {!loading && error && <p className="moderation-error">{error}</p>}
+
+          {!loading && !error && sortedReports.length === 0 && (
+            <p>No active reports.</p>
+          )}
+
+          {!loading && sortedReports.length > 0 && (
+            <div className="moderation-list">
+              {sortedReports.map((report) => {
+                const isExpanded = expandedId === report.id;
+                const isBusy = processingId === report.id;
+
+                return (
+                  <div key={report.id} className="moderation-item">
+                    <div className="moderation-item-header">
+                      <div>
+                        <h3>Report #{report.id.slice(0, 6)}</h3>
+                        <p>Filed: {formatCreatedAt(report.createdAt)}</p>
+                      </div>
+                      <button
+                        type="button"
+                        className="moderation-toggle"
+                        onClick={() => setExpandedId(isExpanded ? "" : report.id)}
+                      >
+                        {isExpanded ? "Hide" : "View"}
+                      </button>
+                    </div>
+
+                    {isExpanded && (
+                      <div className="moderation-details">
+                        <div className="moderation-description">
+                          <strong>Description:</strong>
+                          <p>{report.description || "No description."}</p>
+                        </div>
+
+                        <div className="moderation-people-grid">
+                          <PersonInfo title="Victim" person={report.reporter} />
+                          <PersonInfo
+                            title="Perpetrator"
+                            person={report.accused}
+                          />
+                        </div>
+
+                        <div className="moderation-actions">
+                          <button
+                            type="button"
+                            className="close-report-button"
+                            onClick={() => closeReport(report.id)}
+                            disabled={isBusy}
+                          >
+                            {isBusy ? "Processing..." : "Close Report"}
+                          </button>
+                          <button
+                            type="button"
+                            className="ban-user-button"
+                            onClick={() => openBanConfirmation(report)}
+                            disabled={isBusy}
+                          >
+                            {isBusy ? "Processing..." : "Ban User"}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
       </div>
 
       {pendingBanReport && (

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -7,6 +7,7 @@ const NAV_ITEMS = [
   { icon: "👤", label: "Profile", path: "/profile", group: "top" },
   { icon: "🏠", label: "Home", path: "/dashboard", group: "main" },
   { icon: "✅", label: "My Tasks", path: "/tasks", group: "main" },
+  { icon: "🌍", label: "Public Tasks", path: "/public-tasks", group: "main" },
   { icon: "📅", label: "Calendar", path: "/calendar", group: "main" },
   { icon: "👥", label: "Friends", path: "/friends", group: "main" },
   {

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import axios from "axios";
+import LoadingPage from "./LoadingPage";
 
 const ProtectedRoute = ({
   children,
@@ -54,7 +55,7 @@ const ProtectedRoute = ({
   }, [adminOnly, user?.uid]);
 
   if (authLoading) {
-    return null;
+    return <LoadingPage message="Loading page..." />;
   }
 
   if (!user) {
@@ -62,7 +63,7 @@ const ProtectedRoute = ({
   }
 
   if (adminOnly && isAdmin === null) {
-    return null;
+    return <LoadingPage message="Checking access..." />;
   }
 
   if (adminOnly && !isAdmin) {

--- a/frontend/src/components/task-components/PublicTasksPage.js
+++ b/frontend/src/components/task-components/PublicTasksPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { auth } from "../../firebase";
 import { onAuthStateChanged } from "firebase/auth";
@@ -8,7 +8,8 @@ const PublicTasksPage = () => {
   const [uid, setUid] = useState(null);
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [joiningTaskId, setJoiningTaskId] = useState(null);
+  const [processingTaskId, setProcessingTaskId] = useState(null);
+  const [searchInput, setSearchInput] = useState("");
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
@@ -41,6 +42,40 @@ const PublicTasksPage = () => {
     return joinedUsers.some((joinedUser) => joinedUser?.uid === uid);
   };
 
+  const parsedSearch = useMemo(() => {
+    const normalized = (searchInput || "").trim().toLowerCase();
+    const tokens = normalized.length > 0 ? normalized.split(/\s+/) : [];
+
+    const tagFilters = tokens
+      .filter((token) => token.startsWith("#") && token.length > 1)
+      .map((token) => token.slice(1));
+
+    const titleTerms = tokens.filter((token) => !token.startsWith("#"));
+
+    return {
+      titleQuery: titleTerms.join(" "),
+      tagFilters,
+    };
+  }, [searchInput]);
+
+  const filteredTasks = useMemo(() => {
+    const { titleQuery, tagFilters } = parsedSearch;
+
+    return tasks.filter((task) => {
+      const title = String(task?.title || "").toLowerCase();
+      const taskTags = Array.isArray(task?.tags)
+        ? task.tags.map((tag) => String(tag).toLowerCase())
+        : [];
+
+      const titleMatches = !titleQuery || title.includes(titleQuery);
+      const tagsMatch =
+        tagFilters.length === 0 ||
+        tagFilters.every((filterTag) => taskTags.includes(filterTag));
+
+      return titleMatches && tagsMatch;
+    });
+  }, [tasks, parsedSearch]);
+
   const isTaskFull = (task) => {
     const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
     if (!Number.isInteger(task.peopleNeeded) || task.peopleNeeded <= 0) {
@@ -50,10 +85,10 @@ const PublicTasksPage = () => {
   };
 
   const handleJoinTask = async (task) => {
-    if (!uid || !task?.id || joiningTaskId) return;
+    if (!uid || !task?.id || processingTaskId) return;
 
     try {
-      setJoiningTaskId(task.id);
+      setProcessingTaskId(task.id);
       const response = await axios.post(
         `http://127.0.0.1:5000/public_tasks/${task.id}/join`,
         {
@@ -75,7 +110,37 @@ const PublicTasksPage = () => {
       const message = error?.response?.data?.error || "Unable to join this task.";
       alert(message);
     } finally {
-      setJoiningTaskId(null);
+      setProcessingTaskId(null);
+    }
+  };
+
+  const handleLeaveTask = async (task) => {
+    if (!uid || !task?.id || processingTaskId) return;
+
+    try {
+      setProcessingTaskId(task.id);
+      const response = await axios.post(
+        `http://127.0.0.1:5000/public_tasks/${task.id}/leave`,
+        {
+          userId: uid,
+        },
+      );
+
+      const updatedTask = response?.data?.task;
+      if (updatedTask) {
+        setTasks((prev) =>
+          prev.map((existingTask) =>
+            existingTask.id === task.id
+              ? { ...existingTask, ...updatedTask }
+              : existingTask,
+          ),
+        );
+      }
+    } catch (error) {
+      const message = error?.response?.data?.error || "Unable to leave this task.";
+      alert(message);
+    } finally {
+      setProcessingTaskId(null);
     }
   };
 
@@ -87,18 +152,41 @@ const PublicTasksPage = () => {
       </div>
 
       <section className="tasks-page-section">
+        <div className="public-task-search-wrapper">
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+            placeholder="Search post names (use #tag for tag filtering)"
+            className="public-task-search-input"
+          />
+          <small className="public-task-search-hint">
+            Search title text now. Tag search foundation is enabled via hashtags (example: study #math).
+          </small>
+          {parsedSearch.tagFilters.length > 0 && (
+            <div className="public-task-active-tags">
+              {parsedSearch.tagFilters.map((tag) => (
+                <span key={tag} className="public-task-tag-pill">#{tag}</span>
+              ))}
+            </div>
+          )}
+        </div>
+
         {loading ? (
           <p>Loading public tasks...</p>
         ) : tasks.length === 0 ? (
           <p>No public tasks available right now.</p>
+        ) : filteredTasks.length === 0 ? (
+          <p>No public tasks matched your search.</p>
         ) : (
           <div className="public-tasks-grid">
-            {tasks.map((task) => {
+            {filteredTasks.map((task) => {
               const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
               const ownedByCurrentUser = uid && task.userId === uid;
               const alreadyJoined = hasUserJoinedTask(task);
               const full = isTaskFull(task);
-              const joinDisabled = ownedByCurrentUser || alreadyJoined || full || joiningTaskId === task.id;
+              const joinDisabled = ownedByCurrentUser || alreadyJoined || full || processingTaskId === task.id;
+              const leaveDisabled = !alreadyJoined || processingTaskId === task.id;
 
               return (
                 <article
@@ -118,26 +206,43 @@ const PublicTasksPage = () => {
 
                   <p className="public-task-description">{task.description || "No description."}</p>
 
+                  {Array.isArray(task.tags) && task.tags.length > 0 && (
+                    <div className="public-task-tags">
+                      {task.tags.map((tag) => (
+                        <span key={`${task.id}-${tag}`} className="public-task-tag-pill">#{tag}</span>
+                      ))}
+                    </div>
+                  )}
+
                   <div className="public-task-meta">
                     <small>Status: {task.status || "pending"}</small>
                     <small>Due: {task.dueDate || "No due date"}</small>
                   </div>
 
                   {!ownedByCurrentUser && (
-                    <button
-                      type="button"
-                      className="public-task-join-button"
-                      onClick={() => handleJoinTask(task)}
-                      disabled={joinDisabled}
-                    >
-                      {joiningTaskId === task.id
-                        ? "Joining..."
-                        : alreadyJoined
-                          ? "Joined"
+                    alreadyJoined ? (
+                      <button
+                        type="button"
+                        className="public-task-join-button"
+                        onClick={() => handleLeaveTask(task)}
+                        disabled={leaveDisabled}
+                      >
+                        {processingTaskId === task.id ? "Leaving..." : "Leave Group"}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="public-task-join-button"
+                        onClick={() => handleJoinTask(task)}
+                        disabled={joinDisabled}
+                      >
+                        {processingTaskId === task.id
+                          ? "Joining..."
                           : full
                             ? "Task Full"
                             : "Join"}
-                    </button>
+                      </button>
+                    )
                   )}
 
                   {ownedByCurrentUser && (

--- a/frontend/src/components/task-components/PublicTasksPage.js
+++ b/frontend/src/components/task-components/PublicTasksPage.js
@@ -10,6 +10,16 @@ const PublicTasksPage = () => {
   const [loading, setLoading] = useState(true);
   const [processingTaskId, setProcessingTaskId] = useState(null);
   const [searchInput, setSearchInput] = useState("");
+  const [editingOwnedTask, setEditingOwnedTask] = useState(null);
+  const [savingOwnedTask, setSavingOwnedTask] = useState(false);
+  const [editOwnedForm, setEditOwnedForm] = useState({
+    title: "",
+    dueDate: "",
+    priority: "medium",
+    description: "",
+    visibility: "public",
+    peopleNeeded: "",
+  });
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
@@ -144,6 +154,122 @@ const PublicTasksPage = () => {
     }
   };
 
+  const openOwnedTaskEditModal = (task) => {
+    if (!task?.id) return;
+
+    setEditingOwnedTask(task);
+    setEditOwnedForm({
+      title: task.title || "",
+      dueDate: task.dueDate || "",
+      priority: task.priority || "medium",
+      description: task.description || "",
+      visibility: task.visibility || (task.isPublic ? "public" : "private"),
+      peopleNeeded: Number.isInteger(task.peopleNeeded) ? String(task.peopleNeeded) : "",
+    });
+  };
+
+  const closeOwnedTaskEditModal = () => {
+    if (savingOwnedTask) return;
+
+    setEditingOwnedTask(null);
+    setEditOwnedForm({
+      title: "",
+      dueDate: "",
+      priority: "medium",
+      description: "",
+      visibility: "public",
+      peopleNeeded: "",
+    });
+  };
+
+  const handleOwnedTaskEditSubmit = async (event) => {
+    event.preventDefault();
+    if (!uid || !editingOwnedTask?.id || savingOwnedTask) return;
+
+    const nextTitle = String(editOwnedForm.title || "").trim();
+    if (!nextTitle) {
+      alert("Task title cannot be empty.");
+      return;
+    }
+
+    const normalizedPriority = String(editOwnedForm.priority || "medium").trim().toLowerCase();
+    if (!["low", "medium", "high"].includes(normalizedPriority)) {
+      alert("Priority must be low, medium, or high.");
+      return;
+    }
+
+    const normalizedDueDate = String(editOwnedForm.dueDate || "").trim() || null;
+    const normalizedDescription = String(editOwnedForm.description || "");
+    const titleChanged = nextTitle !== String(editingOwnedTask.title || "").trim();
+    const nextVisibility = editOwnedForm.visibility === "public" ? "public" : "private";
+    const renameForcesPrivate = Boolean(editingOwnedTask.isPublic && titleChanged);
+    const switchedPublicToPrivate = Boolean(editingOwnedTask.isPublic && nextVisibility === "private");
+    const willDisbandPublicPost = renameForcesPrivate || switchedPublicToPrivate;
+    const finalVisibility = renameForcesPrivate ? "private" : nextVisibility;
+
+    let nextPeopleNeeded = null;
+    if (finalVisibility === "public") {
+      const parsedPeopleNeeded = Number(String(editOwnedForm.peopleNeeded || "").trim());
+      if (!Number.isInteger(parsedPeopleNeeded) || parsedPeopleNeeded < 1 || parsedPeopleNeeded > 10) {
+        alert("People needed must be a whole number between 1 and 10.");
+        return;
+      }
+      nextPeopleNeeded = parsedPeopleNeeded;
+    }
+
+    if (willDisbandPublicPost) {
+      const confirmed = window.confirm(
+        "Warning: This change will make the post private and disband the current group (remove joined users). Continue?"
+      );
+      if (!confirmed) return;
+    }
+
+    const payload = {
+      userId: uid,
+      title: nextTitle,
+      description: normalizedDescription,
+      dueDate: normalizedDueDate,
+      priority: normalizedPriority,
+      visibility: finalVisibility,
+      isPublic: finalVisibility === "public",
+      peopleNeeded: finalVisibility === "public" ? nextPeopleNeeded : null,
+    };
+
+    try {
+      setSavingOwnedTask(true);
+      await axios.patch(`http://127.0.0.1:5000/users/${uid}/tasks/${editingOwnedTask.id}`, payload);
+
+      setTasks((prev) => {
+        if (finalVisibility !== "public") {
+          return prev.filter((task) => task.id !== editingOwnedTask.id);
+        }
+
+        return prev.map((task) =>
+          task.id === editingOwnedTask.id
+            ? {
+                ...task,
+                title: nextTitle,
+                description: normalizedDescription,
+                dueDate: normalizedDueDate,
+                priority: normalizedPriority,
+                visibility: finalVisibility,
+                isPublic: true,
+                peopleNeeded: nextPeopleNeeded,
+                ...(willDisbandPublicPost ? { joinedUsers: [] } : {}),
+              }
+            : task
+        );
+      });
+
+      closeOwnedTaskEditModal();
+    } catch (error) {
+      console.error("Error editing owned public post:", error);
+      alert("Could not edit this post. Please try again.");
+    } finally {
+      setSavingOwnedTask(false);
+    }
+  };
+
   return (
     <div className="tasks-page">
       <div className="tasks-page-header">
@@ -161,7 +287,7 @@ const PublicTasksPage = () => {
             className="public-task-search-input"
           />
           <small className="public-task-search-hint">
-            Search title text now. Tag search foundation is enabled via hashtags (example: study #math).
+            Search title text now. Tag search foundation is enabled via hashtags (example: #study #math).
           </small>
           {parsedSearch.tagFilters.length > 0 && (
             <div className="public-task-active-tags">
@@ -246,6 +372,18 @@ const PublicTasksPage = () => {
                   )}
 
                   {ownedByCurrentUser && (
+                    <div className="public-task-owner-actions">
+                      <button
+                        type="button"
+                        className="public-task-join-button"
+                        onClick={() => openOwnedTaskEditModal(task)}
+                      >
+                        Edit Post
+                      </button>
+                    </div>
+                  )}
+
+                  {ownedByCurrentUser && (
                     <div className="joined-users-block">
                       <strong>Joined users:</strong>
                       {joinedUsers.length === 0 ? (
@@ -267,6 +405,126 @@ const PublicTasksPage = () => {
           </div>
         )}
       </section>
+
+      {editingOwnedTask && (
+        <div className="tasks-modal-overlay" onClick={closeOwnedTaskEditModal}>
+          <div className="tasks-modal-content task-edit-modal" onClick={(event) => event.stopPropagation()}>
+            <button
+              type="button"
+              className="tasks-modal-close"
+              onClick={closeOwnedTaskEditModal}
+              aria-label="Close edit public post modal"
+            >
+              ✕
+            </button>
+
+            <h3>Edit Public Post</h3>
+            <form className="task-edit-form" onSubmit={handleOwnedTaskEditSubmit}>
+              <label>
+                Task Name
+                <input
+                  type="text"
+                  value={editOwnedForm.title}
+                  onChange={(event) =>
+                    setEditOwnedForm((prev) => ({ ...prev, title: event.target.value }))
+                  }
+                  required
+                />
+              </label>
+
+              <label>
+                Due Date
+                <input
+                  type="date"
+                  value={editOwnedForm.dueDate || ""}
+                  onChange={(event) =>
+                    setEditOwnedForm((prev) => ({ ...prev, dueDate: event.target.value }))
+                  }
+                />
+              </label>
+
+              <label>
+                Priority
+                <select
+                  className={`priority-select priority-underlined priority-${editOwnedForm.priority || "medium"}`}
+                  value={editOwnedForm.priority}
+                  onChange={(event) =>
+                    setEditOwnedForm((prev) => ({ ...prev, priority: event.target.value }))
+                  }
+                >
+                  <option value="low" className="priority-option">Low</option>
+                  <option value="medium" className="priority-option">Medium</option>
+                  <option value="high" className="priority-option">High</option>
+                </select>
+              </label>
+
+              <label>
+                Description
+                <textarea
+                  rows={4}
+                  value={editOwnedForm.description}
+                  onChange={(event) =>
+                    setEditOwnedForm((prev) => ({ ...prev, description: event.target.value }))
+                  }
+                />
+              </label>
+
+              <label>
+                Visibility
+                <select
+                  value={editOwnedForm.visibility}
+                  onChange={(event) =>
+                    setEditOwnedForm((prev) => ({
+                      ...prev,
+                      visibility: event.target.value,
+                      peopleNeeded:
+                        event.target.value === "public"
+                          ? (prev.peopleNeeded || "1")
+                          : "",
+                    }))
+                  }
+                >
+                  <option value="private">Private</option>
+                  <option value="public">Public (Make it a Post!)</option>
+                </select>
+              </label>
+
+              {editOwnedForm.visibility === "public" && (
+                <label>
+                  People Needed
+                  <input
+                    type="number"
+                    min="1"
+                    max="10"
+                    step="1"
+                    value={editOwnedForm.peopleNeeded}
+                    onChange={(event) =>
+                      setEditOwnedForm((prev) => ({ ...prev, peopleNeeded: event.target.value }))
+                    }
+                    placeholder="How many people are needed? (1-10)"
+                    required
+                  />
+                </label>
+              )}
+
+              {editingOwnedTask.isPublic && (String(editOwnedForm.title || "").trim() !== String(editingOwnedTask.title || "").trim() || editOwnedForm.visibility === "private") && (
+                <p className="task-edit-warning">
+                  Warning: This change will make the post private and disband the current group.
+                </p>
+              )}
+
+              <div className="task-edit-actions">
+                <button type="button" className="task-edit-cancel" onClick={closeOwnedTaskEditModal} disabled={savingOwnedTask}>
+                  Cancel
+                </button>
+                <button type="submit" className="task-edit-save" disabled={savingOwnedTask}>
+                  {savingOwnedTask ? "Saving..." : "Save Changes"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/task-components/PublicTasksPage.js
+++ b/frontend/src/components/task-components/PublicTasksPage.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { auth } from "../../firebase";
 import { onAuthStateChanged } from "firebase/auth";
+import LoadingPage from "../LoadingPage";
 import "../../styles/TaskRelatedStyles.css";
 
 const PublicTasksPage = () => {
@@ -273,6 +274,10 @@ const PublicTasksPage = () => {
     }
   };
 
+  if (loading) {
+    return <LoadingPage message="Loading public tasks..." />;
+  }
+
   return (
     <div className="tasks-page">
       <div className="tasks-page-header">
@@ -301,9 +306,7 @@ const PublicTasksPage = () => {
           )}
         </div>
 
-        {loading ? (
-          <p>Loading public tasks...</p>
-        ) : tasks.length === 0 ? (
+        {tasks.length === 0 ? (
           <p>No public tasks available right now.</p>
         ) : filteredTasks.length === 0 ? (
           <p>No public tasks matched your search.</p>

--- a/frontend/src/components/task-components/PublicTasksPage.js
+++ b/frontend/src/components/task-components/PublicTasksPage.js
@@ -94,6 +94,9 @@ const PublicTasksPage = () => {
     return joinedUsers.length >= task.peopleNeeded;
   };
 
+  const isTaskCompleted = (task) =>
+    String(task?.status || "").trim().toLowerCase() === "completed";
+
   const handleJoinTask = async (task) => {
     if (!uid || !task?.id || processingTaskId) return;
 
@@ -311,7 +314,8 @@ const PublicTasksPage = () => {
               const ownedByCurrentUser = uid && task.userId === uid;
               const alreadyJoined = hasUserJoinedTask(task);
               const full = isTaskFull(task);
-              const joinDisabled = ownedByCurrentUser || alreadyJoined || full || processingTaskId === task.id;
+              const completed = isTaskCompleted(task);
+              const joinDisabled = ownedByCurrentUser || alreadyJoined || full || completed || processingTaskId === task.id;
               const leaveDisabled = !alreadyJoined || processingTaskId === task.id;
 
               return (
@@ -364,7 +368,9 @@ const PublicTasksPage = () => {
                       >
                         {processingTaskId === task.id
                           ? "Joining..."
-                          : full
+                          : completed
+                            ? "Closed"
+                            : full
                             ? "Task Full"
                             : "Join"}
                       </button>

--- a/frontend/src/components/task-components/TaskForm.js
+++ b/frontend/src/components/task-components/TaskForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'; 
+import React, { useEffect, useMemo, useState } from 'react'; 
 import axios from 'axios'; // allows React front-end to interact with the back-end
 import { auth } from '../../firebase';
 import '../../styles/TaskRelatedStyles.css';
@@ -11,6 +11,63 @@ const TaskForm = ({ onTaskAdded }) => {
     const [visibility, setVisibility] = useState('private');
     const [peopleNeeded, setPeopleNeeded] = useState('');
     const [description, setDescription] = useState('');
+    const [availableTags, setAvailableTags] = useState([]);
+    const [selectedTags, setSelectedTags] = useState([]);
+    const [loadingTags, setLoadingTags] = useState(true);
+    const [tagError, setTagError] = useState('');
+    const [tagQuery, setTagQuery] = useState('');
+    const [isTagDropdownOpen, setIsTagDropdownOpen] = useState(false);
+
+    useEffect(() => {
+        const fetchTags = async () => {
+            setLoadingTags(true);
+            setTagError('');
+
+            try {
+                const response = await axios.get('http://127.0.0.1:5000/task_tags');
+                setAvailableTags(Array.isArray(response.data) ? response.data : []);
+            } catch (err) {
+                console.error('Error loading task tags: ', err);
+                setAvailableTags([]);
+                setTagError('Could not load task tags.');
+            } finally {
+                setLoadingTags(false);
+            }
+        };
+
+        fetchTags();
+    }, []);
+
+    const filteredTags = useMemo(() => {
+        const normalizedQuery = tagQuery.trim().toLowerCase();
+
+        return availableTags.filter((tag) => {
+            if (selectedTags.includes(tag)) {
+                return false;
+            }
+
+            if (!normalizedQuery) {
+                return true;
+            }
+
+            return tag.toLowerCase().includes(normalizedQuery);
+        });
+    }, [availableTags, selectedTags, tagQuery]);
+
+    const addSelectedTag = (tag) => {
+        const normalizedTag = String(tag || '').trim();
+        if (!normalizedTag) {
+            return;
+        }
+
+        setSelectedTags((prev) => (prev.includes(normalizedTag) ? prev : [...prev, normalizedTag]));
+        setTagQuery('');
+        setIsTagDropdownOpen(true);
+    };
+
+    const removeSelectedTag = (tag) => {
+        setSelectedTags((prev) => prev.filter((selectedTagValue) => selectedTagValue !== tag));
+    };
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -34,7 +91,8 @@ const TaskForm = ({ onTaskAdded }) => {
             priority: priority,
             visibility: visibility,
             isPublic: visibility === 'public',
-            peopleNeeded: visibility === 'public' && peopleNeeded !== '' ? Number(peopleNeeded) : null
+            peopleNeeded: visibility === 'public' && peopleNeeded !== '' ? Number(peopleNeeded) : null,
+            tags: selectedTags
         };
 
         try{
@@ -46,6 +104,9 @@ const TaskForm = ({ onTaskAdded }) => {
             setVisibility('private');
             setPeopleNeeded('');
             setDescription('');
+            setSelectedTags([]);
+            setTagQuery('');
+            setIsTagDropdownOpen(false);
             if(onTaskAdded) onTaskAdded(); // Refreshes the list after adding
         } catch(err) {
             console.error("Error adding task: ", err);
@@ -126,6 +187,80 @@ const TaskForm = ({ onTaskAdded }) => {
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
                 />
+                <section className="task-tag-section">
+                    <h4>Task Tags</h4>
+                    <p>Type to filter tags from the catalog.</p>
+
+                    {tagError && <p className="task-tag-error">{tagError}</p>}
+
+                    {loadingTags ? (
+                        <p className="task-tag-status">Loading tags...</p>
+                    ) : availableTags.length === 0 ? (
+                        <p className="task-tag-status">No tags available yet.</p>
+                    ) : (
+                        <>
+                            <div className="task-tag-combobox">
+                                <input
+                                    type="text"
+                                    className="task-tag-input"
+                                    placeholder="Start typing to find tags"
+                                    value={tagQuery}
+                                    onChange={(event) => {
+                                        setTagQuery(event.target.value);
+                                        setIsTagDropdownOpen(true);
+                                    }}
+                                    onFocus={() => setIsTagDropdownOpen(true)}
+                                    onBlur={() => {
+                                        window.setTimeout(() => setIsTagDropdownOpen(false), 120);
+                                    }}
+                                />
+
+                                {isTagDropdownOpen && (
+                                    <div className="task-tag-dropdown-menu" role="listbox" aria-label="Task tags">
+                                        {filteredTags.length > 0 ? (
+                                            filteredTags.map((tag) => (
+                                                <div
+                                                    key={tag}
+                                                    className="task-tag-dropdown-item"
+                                                    onClick={() => addSelectedTag(tag)}
+                                                >
+                                                    #{tag}
+                                                </div>
+                                            ))
+                                        ) : (
+                                            <p className="task-tag-status task-tag-dropdown-empty">No matching tags.</p>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+
+                            {selectedTags.length > 0 && (
+                                <div className="task-tag-selected-list">
+                                    {selectedTags.map((tag) => (
+                                        <span key={tag} className="task-tag-selected-chip">
+                                            <span>#{tag}</span>
+                                            <span
+                                                className="task-tag-selected-remove"
+                                                onClick={() => removeSelectedTag(tag)}
+                                                role="button"
+                                                tabIndex={0}
+                                                onKeyDown={(event) => {
+                                                    if (event.key === 'Enter' || event.key === ' ') {
+                                                        event.preventDefault();
+                                                        removeSelectedTag(tag);
+                                                    }
+                                                }}
+                                                aria-label={`Remove ${tag}`}
+                                            >
+                                                ×
+                                            </span>
+                                        </span>
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    )}
+                </section>
                 <button type="submit">Add to UniGenda</button>
         </form>
         </div>

--- a/frontend/src/components/task-components/TaskForm.js
+++ b/frontend/src/components/task-components/TaskForm.js
@@ -11,18 +11,12 @@ const TaskForm = ({ onTaskAdded }) => {
     const [visibility, setVisibility] = useState('private');
     const [peopleNeeded, setPeopleNeeded] = useState('');
     const [description, setDescription] = useState('');
-    const [tags, setTags] = useState('');
 
     const handleSubmit = async (e) => {
         e.preventDefault();
         const user = auth.currentUser;
 
         if(!user) return; // user does not exist
-
-        const parsedTags = tags
-            .split(',')
-            .map((tag) => tag.trim())
-            .filter((tag) => tag.length > 0);
 
         if (visibility === 'public' && peopleNeeded !== '') {
             const parsedPeopleNeeded = Number(peopleNeeded);
@@ -40,8 +34,7 @@ const TaskForm = ({ onTaskAdded }) => {
             priority: priority,
             visibility: visibility,
             isPublic: visibility === 'public',
-            peopleNeeded: visibility === 'public' && peopleNeeded !== '' ? Number(peopleNeeded) : null,
-            tags: parsedTags
+            peopleNeeded: visibility === 'public' && peopleNeeded !== '' ? Number(peopleNeeded) : null
         };
 
         try{
@@ -53,7 +46,6 @@ const TaskForm = ({ onTaskAdded }) => {
             setVisibility('private');
             setPeopleNeeded('');
             setDescription('');
-            setTags('');
             if(onTaskAdded) onTaskAdded(); // Refreshes the list after adding
         } catch(err) {
             console.error("Error adding task: ", err);
@@ -133,12 +125,6 @@ const TaskForm = ({ onTaskAdded }) => {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
-                />
-                <input
-                type="text"
-                placeholder="Tags (comma-separated, e.g., exam, math, group-work)"
-                value={tags}
-                onChange={(e) => setTags(e.target.value)}
                 />
                 <button type="submit">Add to UniGenda</button>
         </form>

--- a/frontend/src/components/task-components/TaskList.js
+++ b/frontend/src/components/task-components/TaskList.js
@@ -13,6 +13,15 @@ const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
   const [openMenuTaskId, setOpenMenuTaskId] = useState(null);
   const [expandedTaskIds, setExpandedTaskIds] = useState({});
   const [activeTab, setActiveTab] = useState('uncompleted'); // 'uncompleted' or 'completed'
+  const [editingTask, setEditingTask] = useState(null);
+  const [editForm, setEditForm] = useState({
+    title: '',
+    dueDate: '',
+    priority: 'medium',
+    description: '',
+    visibility: 'private',
+    peopleNeeded: ''
+  });
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
@@ -80,65 +89,134 @@ const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
     }));
   };
 
-  const editTask = async (task) => {
-    if (!uid || !task?.id) return;
+  const openEditModal = (task) => {
+    if (!task?.id) return;
 
     setOpenMenuTaskId(null);
+    setEditingTask(task);
+    setEditForm({
+      title: task.title || '',
+      dueDate: task.dueDate || '',
+      priority: task.priority || 'medium',
+      description: task.description || '',
+      visibility: task.visibility || (task.isPublic ? 'public' : 'private'),
+      peopleNeeded: Number.isInteger(task.peopleNeeded) ? String(task.peopleNeeded) : ''
+    });
+  };
 
-    const nextTitleInput = window.prompt('Edit task title:', task.title || '');
-    if (nextTitleInput === null) return;
+  const closeEditModal = () => {
+    if (deletingTaskId) return;
+    setEditingTask(null);
+    setEditForm({
+      title: '',
+      dueDate: '',
+      priority: 'medium',
+      description: '',
+      visibility: 'private',
+      peopleNeeded: ''
+    });
+  };
 
-    const nextTitle = nextTitleInput.trim();
+  const handleDeleteFromEditModal = async () => {
+    if (!uid || !editingTask?.id || deletingTaskId) return;
+
+    const confirmed = window.confirm('Are you sure you want to delete this task?');
+    if (!confirmed) return;
+
+    try {
+      setDeletingTaskId(editingTask.id);
+      await axios.delete(`http://127.0.0.1:5000/users/${uid}/tasks/${editingTask.id}`);
+
+      setTasks((prev) => prev.filter((task) => task.id !== editingTask.id));
+      closeEditModal();
+    } catch (err) {
+      console.error('Error deleting task:', err);
+      alert('Could not delete task. Please try again.');
+    } finally {
+      setDeletingTaskId(null);
+    }
+  };
+
+  const handleEditSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!uid || !editingTask?.id) return;
+
+    const nextTitle = String(editForm.title || '').trim();
     if (!nextTitle) {
       alert('Task title cannot be empty.');
       return;
     }
 
-    const nextDescriptionInput = window.prompt('Edit description:', task.description || '');
-    if (nextDescriptionInput === null) return;
-
-    const nextDueDateInput = window.prompt(
-      'Edit due date (YYYY-MM-DD). Leave blank for no due date:',
-      task.dueDate || ''
-    );
-    if (nextDueDateInput === null) return;
-
-    const nextPriorityInput = window.prompt(
-      'Edit priority (low, medium, high):',
-      task.priority || 'medium'
-    );
-    if (nextPriorityInput === null) return;
-
-    const normalizedPriority = String(nextPriorityInput).trim().toLowerCase();
+    const normalizedPriority = String(editForm.priority || 'medium').trim().toLowerCase();
     if (!['low', 'medium', 'high'].includes(normalizedPriority)) {
       alert('Priority must be low, medium, or high.');
       return;
     }
 
-    const normalizedDueDate = nextDueDateInput.trim() ? nextDueDateInput.trim() : null;
+    const normalizedDueDate = String(editForm.dueDate || '').trim() || null;
+    const normalizedDescription = String(editForm.description || '');
+    const titleChanged = nextTitle !== String(editingTask.title || '').trim();
+    const nextVisibility = editForm.visibility === 'public' ? 'public' : 'private';
+    const renameForcesPrivate = Boolean(editingTask.isPublic && titleChanged);
+    const switchedPublicToPrivate = Boolean(editingTask.isPublic && nextVisibility === 'private');
+    const willDisbandPublicPost = renameForcesPrivate || switchedPublicToPrivate;
+    const finalVisibility = renameForcesPrivate ? 'private' : nextVisibility;
+
+    let nextPeopleNeeded = null;
+    if (finalVisibility === 'public') {
+      const parsedPeopleNeeded = Number(String(editForm.peopleNeeded || '').trim());
+      if (!Number.isInteger(parsedPeopleNeeded) || parsedPeopleNeeded < 1 || parsedPeopleNeeded > 10) {
+        alert('People needed must be a whole number between 1 and 10.');
+        return;
+      }
+      nextPeopleNeeded = parsedPeopleNeeded;
+    }
+
+    if (willDisbandPublicPost) {
+      const confirmed = window.confirm(
+        'Warning: This change will make the post private and disband the current group (remove joined users). Continue?'
+      );
+      if (!confirmed) return;
+    }
+
+    const payload = {
+      userId: uid,
+      title: nextTitle,
+      description: normalizedDescription,
+      dueDate: normalizedDueDate,
+      priority: normalizedPriority,
+      visibility: finalVisibility,
+      isPublic: finalVisibility === 'public',
+      peopleNeeded: finalVisibility === 'public' ? nextPeopleNeeded : null
+    };
 
     try {
-      await axios.patch(`http://127.0.0.1:5000/users/${uid}/tasks/${task.id}`, {
-        userId: uid,
-        title: nextTitle,
-        description: nextDescriptionInput,
-        dueDate: normalizedDueDate,
-        priority: normalizedPriority
-      });
+      await axios.patch(`http://127.0.0.1:5000/users/${uid}/tasks/${editingTask.id}`, payload);
 
       setTasks((prev) =>
-        prev.map((t) =>
-          t.id === task.id
+        prev.map((task) =>
+          task.id === editingTask.id
             ? {
-                ...t,
+                ...task,
                 title: nextTitle,
-                description: nextDescriptionInput,
+                description: normalizedDescription,
                 dueDate: normalizedDueDate,
-                priority: normalizedPriority
+                priority: normalizedPriority,
+                visibility: finalVisibility,
+                isPublic: finalVisibility === 'public',
+                peopleNeeded: finalVisibility === 'public' ? nextPeopleNeeded : null,
+                ...(willDisbandPublicPost
+                  ? {
+                      joinedUsers: []
+                    }
+                  : {})
               }
-            : t
+            : task
         )
       );
+
+      closeEditModal();
     } catch (err) {
       console.error('Error editing task:', err);
       alert('Could not edit task. Please try again.');
@@ -228,7 +306,7 @@ const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
                   <button
                     type="button"
                     className="task-item-menu-option"
-                    onClick={() => editTask(task)}
+                    onClick={() => openEditModal(task)}
                   >
                     Edit Task
                   </button>
@@ -345,6 +423,139 @@ const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
               </div>
             )}
           </section>
+        </div>
+      )}
+
+      {editingTask && (
+        <div className="tasks-modal-overlay" onClick={closeEditModal}>
+          <div className="tasks-modal-content task-edit-modal" onClick={(event) => event.stopPropagation()}>
+            <button
+              type="button"
+              className="tasks-modal-close"
+              onClick={closeEditModal}
+              aria-label="Close edit task modal"
+            >
+              ✕
+            </button>
+
+            <h3>Edit Task</h3>
+            <form className="task-edit-form" onSubmit={handleEditSubmit}>
+              <label>
+                Task Name
+                <input
+                  type="text"
+                  value={editForm.title}
+                  onChange={(event) =>
+                    setEditForm((prev) => ({ ...prev, title: event.target.value }))
+                  }
+                  required
+                />
+              </label>
+
+              <label>
+                Due Date
+                <input
+                  type="date"
+                  value={editForm.dueDate || ''}
+                  onChange={(event) =>
+                    setEditForm((prev) => ({ ...prev, dueDate: event.target.value }))
+                  }
+                />
+              </label>
+
+              <label>
+                Priority
+                <select
+                  className={`priority-select priority-underlined priority-${editForm.priority || 'medium'}`}
+                  value={editForm.priority}
+                  onChange={(event) =>
+                    setEditForm((prev) => ({ ...prev, priority: event.target.value }))
+                  }
+                >
+                  <option value="low" className="priority-option">Low</option>
+                  <option value="medium" className="priority-option">Medium</option>
+                  <option value="high" className="priority-option">High</option>
+                </select>
+              </label>
+
+              <label>
+                Description
+                <textarea
+                  rows={4}
+                  value={editForm.description}
+                  onChange={(event) =>
+                    setEditForm((prev) => ({ ...prev, description: event.target.value }))
+                  }
+                />
+              </label>
+
+              <label>
+                Visibility
+                <select
+                  value={editForm.visibility}
+                  onChange={(event) =>
+                    setEditForm((prev) => ({
+                      ...prev,
+                      visibility: event.target.value,
+                      peopleNeeded:
+                        event.target.value === 'public'
+                          ? (prev.peopleNeeded || '1')
+                          : ''
+                    }))
+                  }
+                >
+                  <option value="private">Private</option>
+                  <option value="public">Public (Make it a Post!)</option>
+                </select>
+              </label>
+
+              {editForm.visibility === 'public' && (
+                <label>
+                  People Needed
+                  <input
+                    type="number"
+                    min="1"
+                    max="10"
+                    step="1"
+                    value={editForm.peopleNeeded}
+                    onChange={(event) =>
+                      setEditForm((prev) => ({ ...prev, peopleNeeded: event.target.value }))
+                    }
+                    placeholder="How many people are needed? (1-10)"
+                    required
+                  />
+                </label>
+              )}
+
+              {editingTask.isPublic && (String(editForm.title || '').trim() !== String(editingTask.title || '').trim() || editForm.visibility === 'private') && (
+                <p className="task-edit-warning">
+                  Warning: This change will make the post private and disband the current group.
+                </p>
+              )}
+
+              <div className="task-edit-actions">
+                <button
+                  type="button"
+                  className="task-edit-delete"
+                  onClick={handleDeleteFromEditModal}
+                  disabled={deletingTaskId === editingTask.id}
+                >
+                  {deletingTaskId === editingTask.id ? 'Deleting...' : 'Delete Task'}
+                </button>
+                <button
+                  type="button"
+                  className="task-edit-cancel"
+                  onClick={closeEditModal}
+                  disabled={deletingTaskId === editingTask.id}
+                >
+                  Cancel
+                </button>
+                <button type="submit" className="task-edit-save" disabled={deletingTaskId === editingTask.id}>
+                  Save Changes
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/styles/Dashboard.css
+++ b/frontend/src/styles/Dashboard.css
@@ -112,6 +112,10 @@
   margin: 0 0 8px 0;
 }
 
+.my-public-task-actions {
+  margin: 10px 0 4px 0;
+}
+
 @media (max-width: 980px) {
   .dashboard-bubble-grid {
     grid-template-columns: 1fr;

--- a/frontend/src/styles/Dashboard.css
+++ b/frontend/src/styles/Dashboard.css
@@ -3,26 +3,65 @@
   min-height: 100vh;
   width: 100%;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   background: linear-gradient(120deg, #e8e0ff, #f3f0ff, #d4c9ff, #ede8ff);
   background-size: 300% 300%;
   animation: gradientShift 8s ease infinite;
+  padding: 24px;
+  box-sizing: border-box;
 }
 
 /* 2. The Interface: The actual white box for your dashboard content */
 .dashboard-layout {
-  background: #fff;
   position: relative;
-  padding: 40px;
+  padding: 0;
   width: 100%;
-  max-width: 500px;
-  margin: 40px auto;
+  max-width: 1200px;
+  margin: 0 auto;
   font-family: "Oswald", sans-serif;
-  border: 1px solid #eee;/* Slightly wider for a dashboard feel */
+}
+
+.dashboard-bubble {
+  background: #fff;
+  border: 1px solid #eee;
   border-radius: 16px;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.6);
-  
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.12);
+  padding: 20px;
+}
+
+.dashboard-user-bubble {
+  margin-bottom: 16px;
+}
+
+.dashboard-username {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.dashboard-user-bubble h1 {
+  margin: 4px 0;
+}
+
+.dashboard-user-bubble p {
+  margin: 0;
+}
+
+.dashboard-bubble-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.dashboard-tasks-bubble,
+.dashboard-public-tasks-bubble {
+  min-width: 0;
+}
+
+.dashboard-tasks-bubble h3,
+.dashboard-public-tasks-bubble h3 {
+  margin-top: 0;
 }
 
 /* 3. The Logout Button: Override the general purple button style */
@@ -43,8 +82,40 @@
     transition: background 0.2s;
 }
 
+.dashboard-layout .logout-button {
+  margin-top: 16px;
+}
+
 .logout-button:hover {
     background-color: #cc0000 !important;
+}
+
+.my-public-tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.my-public-task-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  background: #ffffff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.my-public-task-card h4 {
+  margin: 0 0 6px 0;
+}
+
+.my-public-task-card p {
+  margin: 0 0 8px 0;
+}
+
+@media (max-width: 980px) {
+  .dashboard-bubble-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Keep your @keyframes as they are */

--- a/frontend/src/styles/LoadingPage.css
+++ b/frontend/src/styles/LoadingPage.css
@@ -1,0 +1,42 @@
+.loading-page {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.loading-card {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  padding: 20px 24px;
+  min-width: 220px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: "Oswald", sans-serif;
+  color: #111827;
+}
+
+.loading-card p {
+  margin: 0;
+}
+
+.loading-spinner {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 3px solid #ddd6fe;
+  border-top-color: #7c5cfc;
+  animation: loading-spin 0.8s linear infinite;
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/styles/Moderation.css
+++ b/frontend/src/styles/Moderation.css
@@ -25,6 +25,103 @@
   color: #64748b;
 }
 
+.moderation-tag-section {
+  margin: 0 0 1rem;
+  padding: 0.9rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.moderation-tag-section h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.moderation-tag-section p {
+  margin: 0.35rem 0 0.7rem;
+  color: #64748b;
+}
+
+.moderation-tag-add-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.55rem;
+}
+
+.moderation-tag-add-row input {
+  border: 1px solid #cbd5e1;
+  border-radius: 9px;
+  padding: 0.5rem 0.65rem;
+  font-family: "Oswald", sans-serif;
+}
+
+.moderation-tag-add-button {
+  border: none;
+  border-radius: 9px;
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  background: #7c5cfc;
+  color: #ffffff;
+  font-family: "Oswald", sans-serif;
+  font-size: 0.95rem;
+}
+
+.moderation-tag-add-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.moderation-tag-list {
+  margin-top: 0.45rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.moderation-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #c4b5fd;
+  background: #ede9fe;
+  color: #5b21b6;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.8rem;
+  gap: 6px;
+}
+
+
+.moderation-tag-delete {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.moderation-tag-delete:hover {
+  opacity: 0.75;
+}
+
+.moderation-tag-delete:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.moderation-reports-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 2px solid #e2e8f0;
+}
+
+.moderation-reports-section h2 {
+  margin: 0 0 0.7rem;
+  font-size: 1.1rem;
+}
+
 .moderation-error {
   color: #b91c1c;
 }

--- a/frontend/src/styles/TaskRelatedStyles.css
+++ b/frontend/src/styles/TaskRelatedStyles.css
@@ -482,6 +482,10 @@
 	color: #6b7280;
 }
 
+.public-task-owner-actions {
+	margin-bottom: 8px;
+}
+
 .public-task-join-button {
 	border: none;
 	border-radius: 8px;
@@ -515,4 +519,114 @@
 .joined-users-block ul {
 	margin: 6px 0 0 18px;
 	padding: 0;
+}
+
+.task-edit-modal {
+	width: min(560px, 100%);
+	padding: 20px;
+}
+
+.task-edit-modal h3 {
+	margin: 0 0 14px 0;
+}
+
+.task-edit-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.task-edit-form label {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	font-size: 0.95rem;
+	color: #374151;
+}
+
+.task-edit-form input,
+.task-edit-form select,
+.task-edit-form textarea {
+	border: 1px solid #d1d5db;
+	border-radius: 10px;
+	padding: 10px 12px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.95rem;
+	box-sizing: border-box;
+}
+
+.task-edit-form input:focus,
+.task-edit-form select:focus,
+.task-edit-form textarea:focus {
+	outline: none;
+	border-color: #7c5cfc;
+	box-shadow: 0 0 0 2px rgba(124, 92, 252, 0.15);
+}
+
+.task-edit-warning {
+	margin: 0;
+	padding: 10px 12px;
+	border-radius: 10px;
+	border: 1px solid #fca5a5;
+	background: #fef2f2;
+	color: #991b1b;
+	font-size: 0.9rem;
+}
+
+.task-edit-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	margin-top: 6px;
+}
+
+.task-edit-cancel,
+.task-edit-save {
+	border: none;
+	border-radius: 8px;
+	padding: 8px 12px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.9rem;
+	cursor: pointer;
+}
+
+.task-edit-delete {
+	border: none;
+	border-radius: 8px;
+	padding: 8px 12px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.9rem;
+	cursor: pointer;
+	margin-right: auto;
+	background: #ef4444;
+	color: #fff;
+}
+
+.task-edit-delete:hover {
+	background: #dc2626;
+}
+
+.task-edit-cancel {
+	background: #e5e7eb;
+	color: #111827;
+}
+
+.task-edit-cancel:hover {
+	background: #d1d5db;
+}
+
+.task-edit-save {
+	background: #7c5cfc;
+	color: #fff;
+}
+
+.task-edit-save:hover {
+	background: #6a4ae8;
+}
+
+.task-edit-delete:disabled,
+.task-edit-cancel:disabled,
+.task-edit-save:disabled {
+	opacity: 0.65;
+	cursor: not-allowed;
 }

--- a/frontend/src/styles/TaskRelatedStyles.css
+++ b/frontend/src/styles/TaskRelatedStyles.css
@@ -393,3 +393,126 @@
 	background-color: #ffffff;
 	color: #111827;
 }
+
+.public-tasks-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: 14px;
+}
+
+.public-task-search-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-bottom: 14px;
+}
+
+.public-task-search-input {
+	width: 100%;
+	padding: 10px 12px;
+	border: 1px solid #d1d5db;
+	border-radius: 10px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.95rem;
+	box-sizing: border-box;
+}
+
+.public-task-search-input:focus {
+	outline: none;
+	border-color: #7c5cfc;
+	box-shadow: 0 0 0 2px rgba(124, 92, 252, 0.15);
+}
+
+.public-task-search-hint {
+	color: #6b7280;
+}
+
+.public-task-active-tags,
+.public-task-tags {
+	display: flex;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+
+.public-task-tag-pill {
+	display: inline-flex;
+	align-items: center;
+	padding: 4px 8px;
+	border-radius: 999px;
+	background: #ede9fe;
+	color: #5b21b6;
+	font-size: 0.78rem;
+	font-weight: 500;
+}
+
+.public-task-card {
+	border: 1px solid #e5e7eb;
+	border-radius: 12px;
+	padding: 14px;
+	background: #ffffff;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.public-task-card-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 8px;
+}
+
+.public-task-card-header h3 {
+	margin: 0;
+}
+
+.public-task-slot-count {
+	font-size: 0.8rem;
+	color: #4b5563;
+}
+
+.public-task-description {
+	margin: 8px 0 10px 0;
+	color: #111827;
+}
+
+.public-task-meta {
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-bottom: 10px;
+	color: #6b7280;
+}
+
+.public-task-join-button {
+	border: none;
+	border-radius: 8px;
+	padding: 8px 12px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.9rem;
+	background: #7c5cfc;
+	color: #fff;
+	cursor: pointer;
+}
+
+.public-task-join-button:hover {
+	background: #6a4ae8;
+}
+
+.public-task-join-button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.joined-users-block {
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px solid #e5e7eb;
+}
+
+.joined-users-block p {
+	margin: 6px 0 0 0;
+}
+
+.joined-users-block ul {
+	margin: 6px 0 0 18px;
+	padding: 0;
+}

--- a/frontend/src/styles/TaskRelatedStyles.css
+++ b/frontend/src/styles/TaskRelatedStyles.css
@@ -445,6 +445,131 @@
 	font-weight: 500;
 }
 
+.task-tag-section {
+	margin-top: 4px;
+	padding: 12px;
+	border: 1px solid #e2e8f0;
+	border-radius: 12px;
+	background: #f8fafc;
+}
+
+.task-tag-section h4 {
+	margin: 0;
+	font-size: 1rem;
+	color: #111827;
+}
+
+.task-tag-section p {
+	margin: 0.35rem 0 0.7rem;
+	color: #64748b;
+}
+
+.task-tag-combobox {
+	position: relative;
+}
+
+.task-tag-input {
+	display: block;
+	width: 100%;
+	padding: 10px 12px;
+	border: 1px solid #cbd5e1;
+	border-radius: 10px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.95rem;
+	background: #ffffff;
+	color: #111827;
+	box-sizing: border-box;
+}
+
+.task-tag-input:focus {
+	outline: none;
+	border-color: #7c5cfc;
+	box-shadow: 0 0 0 2px rgba(124, 92, 252, 0.15);
+}
+
+.task-tag-dropdown-menu {
+	position: absolute;
+	top: calc(100% + 6px);
+	left: 0;
+	right: 0;
+	z-index: 10;
+	max-height: 220px;
+	overflow-y: auto;
+	padding: 6px;
+	border: 1px solid #cbd5e1;
+	background: #ffffff;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+	gap: 4px;
+}
+
+.task-tag-dropdown-item {
+	display: block;
+	width: 100%;
+	padding: 6px 8px;
+	border: 0;
+	background: transparent;
+	color: #111827;
+	font: inherit;
+	font-family: "Oswald", sans-serif;
+	cursor: pointer;
+	text-align: center;
+	font-size: 0.85rem;
+}
+
+.task-tag-dropdown-item:hover {
+	background: #f3f4f6;
+	border-radius: 4px;
+}
+
+.task-tag-dropdown-empty {
+	margin: 0;
+	padding: 6px 12px;
+}
+
+.task-tag-status,
+.task-tag-error {
+	margin: 0.2rem 0 0.5rem;
+	font-size: 0.9rem;
+}
+
+.task-tag-error {
+	color: #b91c1c;
+}
+
+.task-tag-selected-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.45rem;
+	margin-top: 0.65rem;
+}
+
+.task-tag-selected-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.3rem 0.6rem;
+	border: 1px solid #c4b5fd;
+	border-radius: 999px;
+	background: #ede9fe;
+	color: #5b21b6;
+	font-size: 0.85rem;
+}
+
+.task-tag-selected-remove {
+	display: inline-block;
+	color: inherit;
+	font-size: 1rem;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0;
+	user-select: none;
+}
+
+.task-tag-selected-remove:hover {
+	opacity: 0.75;
+}
+
 .public-task-card {
 	border: 1px solid #e5e7eb;
 	border-radius: 12px;


### PR DESCRIPTION
### **_Main Features Pushed:_**
- **Public Post Page** that displays all posts that have been made public. Other users are able to join these posts until the capacity set by OP has been reached. For OP, anyone who join will have their name displayed to them on their dashboard, in the section relating to their own public posts
- When creating tasks, users are able to input tags that are added by the admins
- Admins are able to **create new tags** through the moderation page
- When a public post is marked as complete, it will be set to be deleted from the public posts database
<img width="1807" height="786" alt="image" src="https://github.com/user-attachments/assets/ffbc510f-866f-4dff-9228-95a91d15249e" />

### **_Other Features:_**
- Changed up the formatting of the dashboard to better incorporate public posts section
- Expanded editing post capabilities to now be able to change practically everything about the post, including its visibility. Changing a post from public to private will disband the group
- **Added a loading page that appears when information is being loaded into a page**
