### PR TITLE
Added Pagination Feature to Task Display

### DIFF
--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { auth } from "../firebase"; 
 import { onAuthStateChanged, signOut } from "firebase/auth"; //
@@ -9,6 +9,9 @@ import TaskForm from './task-components/TaskForm';
 import TaskList from './task-components/TaskList';
 import LoadingPage from "./LoadingPage";
 
+// Number of items to show per page in the dashboard public posts sections
+const DASHBOARD_ITEMS_PER_PAGE = 10;
+
 
 const Dashboard = () => {
     const [userData, setUserData] = useState(null);
@@ -18,6 +21,8 @@ const Dashboard = () => {
     const [showCreateTaskPopup, setShowCreateTaskPopup] = useState(false);
     const [myPublicTasks, setMyPublicTasks] = useState([]);
     const [joinedPublicTasks, setJoinedPublicTasks] = useState([]);
+    const [myPublicPostsPage, setMyPublicPostsPage] = useState(1);
+    const [joinedPublicPostsPage, setJoinedPublicPostsPage] = useState(1);
     const [activePublicPostsTab, setActivePublicPostsTab] = useState("my");
     const [loadingMyPublicTasks, setLoadingMyPublicTasks] = useState(false);
     const [loadingProfile, setLoadingProfile] = useState(true);
@@ -301,7 +306,44 @@ const Dashboard = () => {
             : userData?.school === "SF"
                 ? "Santa Fe College"
                 : userData?.school;
+// The dashboard public posts sections are paginated on the frontend. 
+// We calculate the total pages and the items to show for the current page here.
+    const myPublicPostsTotalPages = Math.max(1, Math.ceil(myPublicTasks.length / DASHBOARD_ITEMS_PER_PAGE));
+    const joinedPublicPostsTotalPages = Math.max(1, Math.ceil(joinedPublicTasks.length / DASHBOARD_ITEMS_PER_PAGE));
 
+    const myPublicPostsPageNumbers = useMemo(
+        () => Array.from({ length: myPublicPostsTotalPages }, (_, index) => index + 1),
+        [myPublicPostsTotalPages],
+    );
+
+    const joinedPublicPostsPageNumbers = useMemo(
+        () => Array.from({ length: joinedPublicPostsTotalPages }, (_, index) => index + 1),
+        [joinedPublicPostsTotalPages],
+    );
+
+    const paginatedMyPublicTasks = useMemo(() => {
+        const startIndex = (myPublicPostsPage - 1) * DASHBOARD_ITEMS_PER_PAGE;
+        return myPublicTasks.slice(startIndex, startIndex + DASHBOARD_ITEMS_PER_PAGE);
+    }, [myPublicTasks, myPublicPostsPage]);
+
+    const paginatedJoinedPublicTasks = useMemo(() => {
+        const startIndex = (joinedPublicPostsPage - 1) * DASHBOARD_ITEMS_PER_PAGE;
+        return joinedPublicTasks.slice(startIndex, startIndex + DASHBOARD_ITEMS_PER_PAGE);
+    }, [joinedPublicTasks, joinedPublicPostsPage]);
+
+    useEffect(() => {
+        setMyPublicPostsPage((page) => Math.min(page, myPublicPostsTotalPages));
+    }, [myPublicPostsTotalPages]);
+
+    useEffect(() => {
+        setJoinedPublicPostsPage((page) => Math.min(page, joinedPublicPostsTotalPages));
+    }, [joinedPublicPostsTotalPages]);
+
+    useEffect(() => {
+        setMyPublicPostsPage(1);
+        setJoinedPublicPostsPage(1);
+    }, [activePublicPostsTab]);
+// Note: The dashboard relies on the profile being loaded to show the welcome message and affiliation, and on the public tasks loading to show the public posts sections, so we show a loading screen until those are ready.
     if (loadingProfile || (authUser?.uid && loadingMyPublicTasks)) {
         return <LoadingPage message="Loading dashboard..." />;
     }
@@ -328,7 +370,7 @@ const Dashboard = () => {
                         </button>
                     </section>
 
-                    <TaskList refreshTrigger={refresh} />
+                    <TaskList refreshTrigger={refresh} limit={null} onlyPrivate={true} enablePagination={true} pageSize={10} />
 
                     </section>
 
@@ -360,8 +402,9 @@ const Dashboard = () => {
                             myPublicTasks.length === 0 ? (
                                 <p>You haven't created any public tasks yet.</p>
                             ) : (
+                                <>
                                 <div className="my-public-tasks-list">
-                                    {myPublicTasks.map((task) => {
+                                    {paginatedMyPublicTasks.map((task) => {
                                         const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
                                         const peopleNeeded = Number.isInteger(task.peopleNeeded) ? task.peopleNeeded : null;
 
@@ -441,13 +484,49 @@ const Dashboard = () => {
                                         );
                                     })}
                                 </div>
+                                <div className="public-task-pagination">
+                                    <button
+                                        type="button"
+                                        className="public-task-page-button"
+                                        onClick={() => setMyPublicPostsPage((page) => Math.max(1, page - 1))}
+                                        disabled={myPublicPostsPage === 1}
+                                    >
+                                        Previous
+                                    </button>
+                                    <div className="public-task-page-numbers" aria-label="Dashboard my public posts page numbers">
+                                        {myPublicPostsPageNumbers.map((pageNumber) => (
+                                            <button
+                                                key={`dashboard-my-public-posts-page-${pageNumber}`}
+                                                type="button"
+                                                className={`public-task-page-button ${myPublicPostsPage === pageNumber ? "public-task-page-button-active" : ""}`}
+                                                onClick={() => setMyPublicPostsPage(pageNumber)}
+                                                aria-current={myPublicPostsPage === pageNumber ? "page" : undefined}
+                                            >
+                                                {pageNumber}
+                                            </button>
+                                        ))}
+                                    </div>
+                                    <span className="public-task-page-indicator">
+                                        Page {myPublicPostsPage} of {myPublicPostsTotalPages}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        className="public-task-page-button"
+                                        onClick={() => setMyPublicPostsPage((page) => Math.min(myPublicPostsTotalPages, page + 1))}
+                                        disabled={myPublicPostsPage >= myPublicPostsTotalPages}
+                                    >
+                                        Next
+                                    </button>
+                                </div>
+                                </>
                             )
                         ) : (
                             joinedPublicTasks.length === 0 ? (
                                 <p>You haven't joined any public posts yet.</p>
                             ) : (
+                                <>
                                 <div className="my-public-tasks-list">
-                                    {joinedPublicTasks.map((task) => {
+                                    {paginatedJoinedPublicTasks.map((task) => {
                                     const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
                                     const peopleNeeded = Number.isInteger(task.peopleNeeded) ? task.peopleNeeded : null;
 
@@ -475,6 +554,41 @@ const Dashboard = () => {
                                     );
                                     })}
                                 </div>
+                                <div className="public-task-pagination">
+                                    <button
+                                        type="button"
+                                        className="public-task-page-button"
+                                        onClick={() => setJoinedPublicPostsPage((page) => Math.max(1, page - 1))}
+                                        disabled={joinedPublicPostsPage === 1}
+                                    >
+                                        Previous
+                                    </button>
+                                    <div className="public-task-page-numbers" aria-label="Dashboard joined public posts page numbers">
+                                        {joinedPublicPostsPageNumbers.map((pageNumber) => (
+                                            <button
+                                                key={`dashboard-joined-public-posts-page-${pageNumber}`}
+                                                type="button"
+                                                className={`public-task-page-button ${joinedPublicPostsPage === pageNumber ? "public-task-page-button-active" : ""}`}
+                                                onClick={() => setJoinedPublicPostsPage(pageNumber)}
+                                                aria-current={joinedPublicPostsPage === pageNumber ? "page" : undefined}
+                                            >
+                                                {pageNumber}
+                                            </button>
+                                        ))}
+                                    </div>
+                                    <span className="public-task-page-indicator">
+                                        Page {joinedPublicPostsPage} of {joinedPublicPostsTotalPages}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        className="public-task-page-button"
+                                        onClick={() => setJoinedPublicPostsPage((page) => Math.min(joinedPublicPostsTotalPages, page + 1))}
+                                        disabled={joinedPublicPostsPage >= joinedPublicPostsTotalPages}
+                                    >
+                                        Next
+                                    </button>
+                                </div>
+                                </>
                             )
                         )}
                     </section>

--- a/frontend/src/components/task-components/PublicTasksPage.js
+++ b/frontend/src/components/task-components/PublicTasksPage.js
@@ -6,6 +6,8 @@ import { onAuthStateChanged } from "firebase/auth";
 import LoadingPage from "../LoadingPage";
 import "../../styles/TaskRelatedStyles.css";
 
+const POSTS_PER_PAGE = 10;
+
 const PublicTasksPage = () => {
   const navigate = useNavigate();
   const [uid, setUid] = useState(null);
@@ -15,6 +17,10 @@ const PublicTasksPage = () => {
   const [searchInput, setSearchInput] = useState("");
   const [editingOwnedTask, setEditingOwnedTask] = useState(null);
   const [savingOwnedTask, setSavingOwnedTask] = useState(false);
+  const [myPostsPage, setMyPostsPage] = useState(1);
+  const [otherPostsPage, setOtherPostsPage] = useState(1);
+  const [showMyPublicPosts, setShowMyPublicPosts] = useState(true);
+  const [showOtherPublicPosts, setShowOtherPublicPosts] = useState(true);
   const [editOwnedForm, setEditOwnedForm] = useState({
     title: "",
     dueDate: "",
@@ -106,6 +112,40 @@ const PublicTasksPage = () => {
       return bJoined - aJoined;
     });
   }, [publicTasksInUniGenda, uid]);
+
+  const myPostsTotalPages = Math.max(1, Math.ceil(myPublicTasks.length / POSTS_PER_PAGE));
+  const otherPostsTotalPages = Math.max(1, Math.ceil(orderedPublicTasksInUniGenda.length / POSTS_PER_PAGE));
+  const myPostsPageNumbers = useMemo(
+    () => Array.from({ length: myPostsTotalPages }, (_, index) => index + 1),
+    [myPostsTotalPages],
+  );
+  const otherPostsPageNumbers = useMemo(
+    () => Array.from({ length: otherPostsTotalPages }, (_, index) => index + 1),
+    [otherPostsTotalPages],
+  );
+
+  const paginatedMyPublicTasks = useMemo(() => {
+    const startIndex = (myPostsPage - 1) * POSTS_PER_PAGE;
+    return myPublicTasks.slice(startIndex, startIndex + POSTS_PER_PAGE);
+  }, [myPublicTasks, myPostsPage]);
+
+  const paginatedOtherPublicTasks = useMemo(() => {
+    const startIndex = (otherPostsPage - 1) * POSTS_PER_PAGE;
+    return orderedPublicTasksInUniGenda.slice(startIndex, startIndex + POSTS_PER_PAGE);
+  }, [orderedPublicTasksInUniGenda, otherPostsPage]);
+
+  useEffect(() => {
+    setMyPostsPage((currentPage) => Math.min(currentPage, myPostsTotalPages));
+  }, [myPostsTotalPages]);
+
+  useEffect(() => {
+    setOtherPostsPage((currentPage) => Math.min(currentPage, otherPostsTotalPages));
+  }, [otherPostsTotalPages]);
+
+  useEffect(() => {
+    setMyPostsPage(1);
+    setOtherPostsPage(1);
+  }, [parsedSearch.titleQuery, parsedSearch.tagFilters.join("|")]);
 
   const isTaskFull = (task) => {
     const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
@@ -390,12 +430,22 @@ const PublicTasksPage = () => {
         ) : (
           <div className="public-tasks-section-stack">
             <section className="public-tasks-subsection">
-              <h2>My Public Posts</h2>
-              {myPublicTasks.length === 0 ? (
+              <div className="public-tasks-subsection-header">
+                <h2>My Public Posts</h2>
+                <button
+                  type="button"
+                  className="public-tasks-section-toggle"
+                  onClick={() => setShowMyPublicPosts((prev) => !prev)}
+                >
+                  {showMyPublicPosts ? "Hide" : "Expand"}
+                </button>
+              </div>
+              {showMyPublicPosts && (myPublicTasks.length === 0 ? (
                 <p>You haven't created any public posts yet.</p>
               ) : (
+                <>
                 <div className="public-tasks-grid">
-                  {myPublicTasks.map((task) => {
+                  {paginatedMyPublicTasks.map((task) => {
                     const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
 
                     return (
@@ -494,16 +544,61 @@ const PublicTasksPage = () => {
                     );
                   })}
                 </div>
-              )}
+                <div className="public-task-pagination">
+                  <button
+                    type="button"
+                    className="public-task-page-button"
+                    onClick={() => setMyPostsPage((page) => Math.max(1, page - 1))}
+                    disabled={myPostsPage === 1}
+                  >
+                    Previous
+                  </button>
+                  <div className="public-task-page-numbers" aria-label="My public posts page numbers">
+                    {myPostsPageNumbers.map((pageNumber) => (
+                      <button
+                        key={`my-post-page-${pageNumber}`}
+                        type="button"
+                        className={`public-task-page-button ${myPostsPage === pageNumber ? "public-task-page-button-active" : ""}`}
+                        onClick={() => setMyPostsPage(pageNumber)}
+                        aria-current={myPostsPage === pageNumber ? "page" : undefined}
+                      >
+                        {pageNumber}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="public-task-page-indicator">
+                    Page {myPostsPage} of {myPostsTotalPages}
+                  </span>
+                  <button
+                    type="button"
+                    className="public-task-page-button"
+                    onClick={() => setMyPostsPage((page) => Math.min(myPostsTotalPages, page + 1))}
+                    disabled={myPostsPage >= myPostsTotalPages}
+                  >
+                    Next
+                  </button>
+                </div>
+                </>
+              ))}
             </section>
 
             <section className="public-tasks-subsection">
-              <h2>Public Posts in UniGenda</h2>
-              {orderedPublicTasksInUniGenda.length === 0 ? (
+              <div className="public-tasks-subsection-header">
+                <h2>Public Posts in UniGenda</h2>
+                <button
+                  type="button"
+                  className="public-tasks-section-toggle"
+                  onClick={() => setShowOtherPublicPosts((prev) => !prev)}
+                >
+                  {showOtherPublicPosts ? "Hide" : "Expand"}
+                </button>
+              </div>
+              {showOtherPublicPosts && (orderedPublicTasksInUniGenda.length === 0 ? (
                 <p>No public posts from other students matched your search.</p>
               ) : (
+                <>
                 <div className="public-tasks-grid">
-                  {orderedPublicTasksInUniGenda.map((task) => {
+                  {paginatedOtherPublicTasks.map((task) => {
                     const joinedUsers = Array.isArray(task.joinedUsers) ? task.joinedUsers : [];
                     const alreadyJoined = hasUserJoinedTask(task);
                     const full = isTaskFull(task);
@@ -571,7 +666,42 @@ const PublicTasksPage = () => {
                     );
                   })}
                 </div>
-              )}
+                <div className="public-task-pagination">
+                  <button
+                    type="button"
+                    className="public-task-page-button"
+                    onClick={() => setOtherPostsPage((page) => Math.max(1, page - 1))}
+                    disabled={otherPostsPage === 1}
+                  >
+                    Previous
+                  </button>
+                  <div className="public-task-page-numbers" aria-label="Public posts in UniGenda page numbers">
+                    {otherPostsPageNumbers.map((pageNumber) => (
+                      <button
+                        key={`other-post-page-${pageNumber}`}
+                        type="button"
+                        className={`public-task-page-button ${otherPostsPage === pageNumber ? "public-task-page-button-active" : ""}`}
+                        onClick={() => setOtherPostsPage(pageNumber)}
+                        aria-current={otherPostsPage === pageNumber ? "page" : undefined}
+                      >
+                        {pageNumber}
+                      </button>
+                    ))}
+                  </div>
+                  <span className="public-task-page-indicator">
+                    Page {otherPostsPage} of {otherPostsTotalPages}
+                  </span>
+                  <button
+                    type="button"
+                    className="public-task-page-button"
+                    onClick={() => setOtherPostsPage((page) => Math.min(otherPostsTotalPages, page + 1))}
+                    disabled={otherPostsPage >= otherPostsTotalPages}
+                  >
+                    Next
+                  </button>
+                </div>
+                </>
+              ))}
             </section>
           </div>
         )}

--- a/frontend/src/components/task-components/TaskList.js
+++ b/frontend/src/components/task-components/TaskList.js
@@ -1,10 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
 import { auth } from '../../firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import '../../styles/TaskRelatedStyles.css';
 
-const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
+const TaskList = ({
+  refreshTrigger,
+  limit = 10,
+  showAllStatuses = false,
+  enablePagination = false,
+  pageSize = 10,
+  onlyPrivate = false
+}) => {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [uid, setUid] = useState(null);
@@ -13,6 +20,7 @@ const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
   const [openMenuTaskId, setOpenMenuTaskId] = useState(null);
   const [expandedTaskIds, setExpandedTaskIds] = useState({});
   const [activeTab, setActiveTab] = useState('uncompleted'); // 'uncompleted' or 'completed'
+  const [currentPage, setCurrentPage] = useState(1);
   const [editingTask, setEditingTask] = useState(null);
   const [editForm, setEditForm] = useState({
     title: '',
@@ -244,11 +252,44 @@ const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
     }
   };
 
-  const completedTasks = tasks.filter((task) => task.status === 'completed');
-  const uncompletedTasks = tasks.filter((task) => task.status !== 'completed');
+  const filteredByVisibilityTasks = useMemo(() => {
+    if (!onlyPrivate) {
+      return tasks;
+    }
+
+    return tasks.filter((task) => {
+      const taskVisibility = String(task?.visibility || (task?.isPublic ? 'public' : 'private')).trim().toLowerCase();
+      return taskVisibility !== 'public';
+    });
+  }, [tasks, onlyPrivate]);
+
+  const completedTasks = filteredByVisibilityTasks.filter((task) => task.status === 'completed');
+  const uncompletedTasks = filteredByVisibilityTasks.filter((task) => task.status !== 'completed');
 
   // Filter tasks based on active tab
   const filteredTasks = activeTab === 'completed' ? completedTasks : uncompletedTasks;
+  const normalizedPageSize = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 10;
+  const totalPages = Math.max(1, Math.ceil(filteredTasks.length / normalizedPageSize));
+  const pageNumbers = Array.from({ length: totalPages }, (_, index) => index + 1);
+
+  const paginatedFilteredTasks = useMemo(() => {
+    if (!enablePagination || showAllStatuses) {
+      return filteredTasks;
+    }
+
+    const startIndex = (currentPage - 1) * normalizedPageSize;
+    return filteredTasks.slice(startIndex, startIndex + normalizedPageSize);
+  }, [filteredTasks, enablePagination, showAllStatuses, currentPage, normalizedPageSize]);
+
+  useEffect(() => {
+    if (!enablePagination || showAllStatuses) return;
+    setCurrentPage((page) => Math.min(page, totalPages));
+  }, [enablePagination, showAllStatuses, totalPages]);
+
+  useEffect(() => {
+    if (!enablePagination || showAllStatuses) return;
+    setCurrentPage(1);
+  }, [enablePagination, showAllStatuses, activeTab]);
 
   const renderTaskItems = (taskItems) => (
     taskItems.map(task => (
@@ -390,7 +431,45 @@ const TaskList = ({ refreshTrigger, limit = 10, showAllStatuses = false }) => {
 
       {!showAllStatuses ? (
         filteredTasks.length > 0 ? (
-          renderTaskItems(filteredTasks)
+          <>
+            {renderTaskItems(paginatedFilteredTasks)}
+            {enablePagination && (
+              <div className="public-task-pagination">
+                <button
+                  type="button"
+                  className="public-task-page-button"
+                  onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                  disabled={currentPage === 1}
+                >
+                  Previous
+                </button>
+                <div className="public-task-page-numbers" aria-label="Dashboard private tasks page numbers">
+                  {pageNumbers.map((pageNumber) => (
+                    <button
+                      key={`dashboard-private-tasks-page-${pageNumber}`}
+                      type="button"
+                      className={`public-task-page-button ${currentPage === pageNumber ? 'public-task-page-button-active' : ''}`}
+                      onClick={() => setCurrentPage(pageNumber)}
+                      aria-current={currentPage === pageNumber ? 'page' : undefined}
+                    >
+                      {pageNumber}
+                    </button>
+                  ))}
+                </div>
+                <span className="public-task-page-indicator">
+                  Page {currentPage} of {totalPages}
+                </span>
+                <button
+                  type="button"
+                  className="public-task-page-button"
+                  onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                  disabled={currentPage >= totalPages}
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
         ) : (
           <div className="empty-tasks">
             <p>

--- a/frontend/src/styles/TaskRelatedStyles.css
+++ b/frontend/src/styles/TaskRelatedStyles.css
@@ -400,6 +400,79 @@
 	gap: 14px;
 }
 
+.public-tasks-subsection-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	margin-bottom: 10px;
+}
+
+.public-tasks-subsection-header h2 {
+	margin: 0;
+}
+
+.public-tasks-section-toggle {
+	border: 1px solid #c7d2fe;
+	border-radius: 8px;
+	padding: 6px 10px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.85rem;
+	background: #eef2ff;
+	color: #4338ca;
+	cursor: pointer;
+}
+
+.public-tasks-section-toggle:hover {
+	background: #e0e7ff;
+}
+
+.public-task-pagination {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-top: 14px;
+}
+
+.public-task-page-numbers {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+
+.public-task-page-button {
+	border: none;
+	border-radius: 8px;
+	padding: 8px 12px;
+	font-family: "Oswald", sans-serif;
+	font-size: 0.9rem;
+	background: #7c5cfc;
+	color: #ffffff;
+	cursor: pointer;
+}
+
+.public-task-page-button:hover {
+	background: #6a4ae8;
+}
+
+.public-task-page-button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.public-task-page-button-active {
+	background: #4f46e5;
+	box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
+}
+
+.public-task-page-indicator {
+	color: #4b5563;
+	font-size: 0.9rem;
+}
+
 .public-task-search-wrapper {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Reduces the amount of tasks that can be displayed on the dashboard and public post page, and instead makes them traversable through different pages.
This applies to the dashboard and public posts displays. 